### PR TITLE
feat,fix(priory): basic error handling and logging.  Fixed happy path.

### DIFF
--- a/priory/src/bootstrap.rs
+++ b/priory/src/bootstrap.rs
@@ -1,10 +1,7 @@
 use anyhow::{Context, Result};
-use libp2p::{
-    core::PeerId,
-    swarm::{DialError, SwarmEvent},
-};
+use libp2p::{core::PeerId, swarm::SwarmEvent};
 use tokio::sync::mpsc::{Receiver, Sender};
-use tracing::info;
+use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::config::Config;
 use crate::swarm_client::SwarmClient;
@@ -13,10 +10,10 @@ use crate::{MyBehaviourEvent, Peer};
 // These are the events that we need some information from during bootstrapping.
 // When encountered in the main thread, the specified data is copied here and the
 // event is also handled by the common handler.
+#[derive(Debug)]
 pub enum BootstrapEvent {
     ConnectionEstablished { peer_id: PeerId },
-    OutgoingConnectionErrorLikelyFirewall,
-    OutgoingConnectionErrorOther,
+    OutgoingConnectionError,
 }
 
 impl BootstrapEvent {
@@ -25,58 +22,58 @@ impl BootstrapEvent {
             SwarmEvent::ConnectionEstablished { peer_id, .. } => {
                 Some(BootstrapEvent::ConnectionEstablished { peer_id: *peer_id })
             }
-            SwarmEvent::OutgoingConnectionError { error, .. } => match error {
-                DialError::Transport(_) => {
-                    Some(BootstrapEvent::OutgoingConnectionErrorLikelyFirewall)
-                }
-                _ => Some(BootstrapEvent::OutgoingConnectionErrorOther),
-            },
+            SwarmEvent::OutgoingConnectionError { .. } => {
+                Some(BootstrapEvent::OutgoingConnectionError)
+            }
             _ => None,
         }
     }
 }
 
+#[instrument(skip_all)]
 pub async fn bootstrap(
     cfg: Config,
     event_receiver: &mut Receiver<BootstrapEvent>,
     holepunch_req_sender: Sender<PeerId>,
     swarm_client: SwarmClient,
 ) -> Result<()> {
-    info!("BOOTSTRAPPING");
+    info!("Bootstrapping");
 
     // keep track of the nodes that we'll later have to hole punch into
     let mut failed_to_dial: Vec<Peer> = Vec::new();
 
+    debug!("dialing {} peers", &cfg.peers.len());
     // try to dial all peers in config
-    for peer in &cfg.peers.clone() {
+    for peer in &cfg.peers {
         let peer_multiaddr = &peer.multiaddr;
 
         // dial peer
         // if successful add to DHT
         // if failure wait until we've made contact with the dht and find a peer to holepunch
-        swarm_client.dial(peer_multiaddr.clone()).await.unwrap();
+        swarm_client
+            .dial(peer_multiaddr.clone())
+            .await
+            .context("bootstrap dial of {:peer_multiaddr?}")?;
+        debug!(?peer_multiaddr, peer_id = ?peer.peer_id, "dialing");
 
         // loop until we either connect or fail to connect
         loop {
             match event_receiver
                 .recv()
                 .await
-                .context("bootstrap event sender shouldn't drop")
-                .unwrap()
+                .context("bootstrap event sender shouldn't drop")?
             {
                 BootstrapEvent::ConnectionEstablished { peer_id, .. } => {
                     // have to make sure this event is about the node we just dialed
                     if peer_id == peer.peer_id {
+                        trace!(?peer_id, "Connection Established");
                         break;
                     }
                 }
-                BootstrapEvent::OutgoingConnectionErrorLikelyFirewall => {
+                BootstrapEvent::OutgoingConnectionError => {
+                    warn!(dialed_peer_id=?peer.peer_id, "Connection error after dialing, possibly firewall");
                     // TODO: have to make sure this event is about the node we just dialed (how???)
                     failed_to_dial.push(peer.clone());
-                    break;
-                }
-                BootstrapEvent::OutgoingConnectionErrorOther => {
-                    // TODO: have to make sure this event is about the node we just dialed (how???)
                     break;
                 }
             }
@@ -85,13 +82,22 @@ pub async fn bootstrap(
 
     // unable to dial any of the peers you listed
     if failed_to_dial.len() == cfg.peers.len() && !cfg.peers.is_empty() {
-        panic!("Couldn't connect to any adress listed as a peer in the config");
+        error!("Couldn't connect to any address listed as a peer in the config.  Exiting.");
+        panic!("Couldn't connect to any address listed as a peer in the config.  Exiting.");
     }
+
+    let successful_dials = cfg.peers.len() - failed_to_dial.len();
+    let unsuccessful_dials = failed_to_dial.len();
+    info!(successful_dials, unsuccessful_dials, "Bootstrap complete.");
 
     for peer in failed_to_dial {
-        holepunch_req_sender.send(peer.peer_id).await.unwrap();
+        let peer_id = peer.peer_id;
+        info!(peer_multiaddr=?peer.multiaddr, ?peer_id, "sending holepunch request");
+        holepunch_req_sender
+            .send(peer.peer_id)
+            .await
+            .context("request hole punch peer that failed bootstrap dial {:peer_id?}")?;
     }
 
-    info!("BOOTSTRAP COMPLETE");
     Ok(())
 }

--- a/priory/src/config.rs
+++ b/priory/src/config.rs
@@ -1,5 +1,5 @@
 use crate::Peer;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::Deserialize;
 use std::fs;
 
@@ -123,8 +123,10 @@ fn default_gossipsub_connections_upper_tolerance() -> usize {
 
 impl Config {
     pub fn parse(config_file_path: &str) -> Result<Self> {
-        let config_content = fs::read_to_string(config_file_path)?;
-        let config: Config = toml::from_str(&config_content)?;
+        let config_content = fs::read_to_string(config_file_path)
+            .context("read config file {config_file_path} to string")?;
+        let config: Config = toml::from_str(&config_content)
+            .context("deserialize config file {config_file_path} from toml")?;
         Ok(config)
     }
 }

--- a/sigil/.env.build
+++ b/sigil/.env.build
@@ -1,5 +1,5 @@
 OVERRIDES="
 libp2p;../../rust-libp2p/libp2p/;https://github.com/unattended-backpack/rust-libp2p.git;.git,.github,docs,examples,hole-punching-tests,interop-tests,scripts,swarm-test,target,wasm-tests,.dockerignore,.editorconfig,.git-blame-ignore-revs,.gitignore,CHANGELOG.md,clippy.toml,CONTRIBUTING.md,deny.toml,FUNDING.json,LICENSE,README.md,ROADMAP.md,SECURITY.md
-priory;../priory;https://github.com/JossDuff/monorepo/tree/dev/priory;target
+priory;../priory;https://github.com/JossDuff/monorepo.git;target
 "
 

--- a/sigil/Cargo.lock
+++ b/sigil/Cargo.lock
@@ -3009,7 +3009,6 @@ dependencies = [
 [[package]]
 name = "priory"
 version = "0.1.0"
-source = "git+https://github.com/JossDuff/monorepo.git?branch=dev#51d4d4c0633b8feea194e9c168a3130b655daa93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4876,7 +4875,3 @@ dependencies = [
  "quote",
  "syn 2.0.77",
 ]
-
-[[patch.unused]]
-name = "priory"
-version = "0.1.0"


### PR DESCRIPTION
Added more tracing logs for priory.  Previously was relying on traces from libp2p which made it understandably hard to debug priory specific issues.  

Fixed a bug during bootstrapping where an unsuccessful dial wouldn't always result in a holepunch attempt.

Added basic error handling.  Mostly `anyhow` `.context()` and `?` propagation.  Remove all `unwrap()` and `assert!()` and `panic()` (or at least almost all).

This should just be a first pass at error handling and tracing to aid in feature development.  When we are more settled with the features of priory we should re-visit proper retry logic and sensible traces.