### PR TITLE
fix: `prover.setup` for each proof request

### DIFF
--- a/sigil/op-succinct/proposer/succinct/bin/minimal-server.rs
+++ b/sigil/op-succinct/proposer/succinct/bin/minimal-server.rs
@@ -1,6 +1,5 @@
 use alloy_primitives::B256;
 use anyhow::Result;
-use cargo_metadata::MetadataCommand;
 use log::{error, info};
 use op_succinct_client_utils::{boot::BootInfoStruct, types::u32_to_u8};
 use op_succinct_host_utils::{

--- a/sigil/op-succinct/proposer/succinct/bin/minimal-server.rs
+++ b/sigil/op-succinct/proposer/succinct/bin/minimal-server.rs
@@ -11,7 +11,7 @@ use op_succinct_host_utils::{
     ProgramType,
 };
 use op_succinct_proposer::SpanProofRequest;
-use sp1_sdk::{utils, HashableKey, ProverClient, SP1Proof, SP1VerifyingKey, SP1ProofWithPublicValues};
+use sp1_sdk::{utils, HashableKey, ProverClient, SP1Proof, SP1VerifyingKey, Prover, SP1ProofWithPublicValues};
 use std::{fs, str::FromStr};
 
 pub const RANGE_ELF: &[u8] = include_bytes!("../../../elf/range-elf");
@@ -108,7 +108,7 @@ async fn main() -> Result<()> {
 
     // Save the proof to the proof directory corresponding to the chain ID.
     proof
-        .save(proof_path)
+        .save(&proof_path)
         .expect("saving proof failed");
 
     info!("saved proof to {}", proof_path);

--- a/sigil/op-succinct/proposer/succinct/bin/minimal-server.rs
+++ b/sigil/op-succinct/proposer/succinct/bin/minimal-server.rs
@@ -1,37 +1,32 @@
 use alloy_primitives::B256;
 use anyhow::Result;
+use cargo_metadata::MetadataCommand;
 use log::{error, info};
-use op_succinct_client_utils::types::u32_to_u8;
+use op_succinct_client_utils::{boot::BootInfoStruct, types::u32_to_u8};
 use op_succinct_host_utils::{
     fetcher::{CacheMode, OPSuccinctDataFetcher, RunContext},
     get_proof_stdin,
     witnessgen::{WitnessGenExecutor, WITNESSGEN_TIMEOUT},
     ProgramType,
 };
-use op_succinct_proposer::{
-    SpanProofRequest
-};
-use sp1_sdk::{
-    HashableKey,
-    utils, ProverClient 
-};
-use std::{str::FromStr}; 
-
+use op_succinct_proposer::SpanProofRequest;
+use sp1_sdk::{utils, HashableKey, ProverClient, SP1Proof, SP1VerifyingKey};
+use std::{fs, str::FromStr};
 
 pub const RANGE_ELF: &[u8] = include_bytes!("../../../elf/range-elf");
 pub const AGG_ELF: &[u8] = include_bytes!("../../../elf/aggregation-elf");
 
 #[tokio::main]
 async fn main() -> Result<()> {
-
+    let l2_start_block = 250551;
+    let l2_end_block = 250556;
     // dummy payload
     let payload = SpanProofRequest {
         // start: 113137,
         // end: 113437
-        start: 250551,
-        end: 250556
-        // start: 250330,
-        // end: 250331
+        start: l2_start_block,
+        end: l2_end_block, // start: 250330,
+                           // end: 250331
     };
     utils::setup_logger();
 
@@ -64,10 +59,7 @@ async fn main() -> Result<()> {
         Ok(cli) => cli,
         Err(e) => {
             error!("Failed to get host CLI args: {}", e);
-            return Err(anyhow::anyhow!(
-                "Failed to get host CLI args: {}",
-                e
-            ));
+            return Err(anyhow::anyhow!("Failed to get host CLI args: {}", e));
         }
     };
 
@@ -77,37 +69,105 @@ async fn main() -> Result<()> {
     let mut witnessgen_executor = WitnessGenExecutor::new(WITNESSGEN_TIMEOUT, RunContext::Docker);
     if let Err(e) = witnessgen_executor.spawn_witnessgen(&host_cli).await {
         error!("Failed to spawn witness generation: {}", e);
-        return Err(anyhow::anyhow!(
-            "Failed to spawn witness generation: {}",
-            e
-        ));
+        return Err(anyhow::anyhow!("Failed to spawn witness generation: {}", e));
     }
     // Log any errors from running the witness generation process.
     if let Err(e) = witnessgen_executor.flush().await {
         error!("Failed to generate witness: {}", e);
-        return Err(anyhow::anyhow!(
-            "Failed to generate witness: {}",
-            e
-        ));
+        return Err(anyhow::anyhow!("Failed to generate witness: {}", e));
     }
 
     let sp1_stdin = match get_proof_stdin(&host_cli) {
         Ok(stdin) => stdin,
         Err(e) => {
             error!("Failed to get proof stdin: {}", e);
-            return Err(anyhow::anyhow!(
-                "Failed to get proof stdin: {}",
-                e
-            ));
+            return Err(anyhow::anyhow!("Failed to get proof stdin: {}", e));
         }
     };
 
     info!("executing span proof");
 
-    let _proof_res = prover.prove(&range_pk, &sp1_stdin).compressed().run().unwrap();
-    
-    info!("done with proof");
+    let proof = prover
+        .prove(&range_pk, &sp1_stdin)
+        .compressed()
+        .run()
+        .unwrap();
+
+    info!("done with span proof");
+
+    // Create a proof directory for the chain ID if it doesn't exist.
+    let proof_dir = "proofs/".to_string();
+    if !std::path::Path::new(&proof_dir).exists() {
+        fs::create_dir_all(&proof_dir).unwrap();
+    }
+    let proof_path = format!(
+            "{}/{}-{}.bin",
+            proof_dir, l2_start_block, l2_end_block
+        );
+
+    // Save the proof to the proof directory corresponding to the chain ID.
+    proof
+        .save(proof_path)
+        .expect("saving proof failed");
+
+    info!("saved proof to {}", proof_path);
+
+    let prover = ProverClient::from_env();
+    let (_, vkey) = prover.setup(RANGE_ELF);
+    let (proofs, boot_infos) = load_aggregation_proof_data(proof_path, &vkey);
+
+    info!("loaded saved proof");
+
+    let header = fetcher.get_latest_l1_head_in_batch(&boot_infos).await?;
+    let headers = fetcher
+        .get_header_preimages(&boot_infos, header.hash_slow())
+        .await?;
+    let multi_block_vkey_u8 = u32_to_u8(vkey.vk.hash_u32());
+    let multi_block_vkey_b256 = B256::from(multi_block_vkey_u8);
+    // println!(
+    //     "Range ELF Verification Key Commitment: {}",
+    //     multi_block_vkey_b256
+    // );
+    let stdin =
+        get_agg_proof_stdin(proofs, boot_infos, headers, &vkey, header.hash_slow()).unwrap();
+
+    let (agg_pk, agg_vk) = prover.setup(AGG_ELF);
+    // println!("Aggregate ELF Verification Key: {:?}", agg_vk.vk.bytes32());
+    //
+    //
+    info!("executing agg proof");
+    let _proof_res = prover
+        .prove(&agg_pk, &stdin)
+        .groth16()
+        .run()
+        .expect("proving failed");
+
+    info!("done with agg proof");
 
     Ok(())
 }
 
+/// Load the aggregation proof data.
+fn load_aggregation_proof_data(
+    proof_path: String,
+    range_vkey: &SP1VerifyingKey,
+) -> (SP1Proof, BootInfoStruct) {
+
+    if fs::metadata(&proof_path).is_err() {
+        panic!("Proof file not found: {}", proof_path);
+    }
+    let mut deserialized_proof =
+        SP1ProofWithPublicValues::load(proof_path).expect("loading proof failed");
+
+    prover
+        .verify(&deserialized_proof, range_vkey)
+        .expect("proof verification failed");
+
+    proofs.push(deserialized_proof.proof);
+
+    // The public values are the BootInfoStruct.
+    let boot_info = deserialized_proof.public_values.read();
+
+    ( deserialized_proof.proof, boot_info)
+
+}

--- a/sigil/op-succinct/proposer/succinct/bin/minimal-server.rs
+++ b/sigil/op-succinct/proposer/succinct/bin/minimal-server.rs
@@ -18,27 +18,25 @@ pub const AGG_ELF: &[u8] = include_bytes!("../../../elf/aggregation-elf");
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let l2_start_block = 250551;
-    let l2_end_block = 250556;
+    let l2_start_block = 12500;
+    let l2_end_block = 12501;
+
     // dummy payload
     let payload = SpanProofRequest {
-        // start: 113137,
-        // end: 113437
         start: l2_start_block,
-        end: l2_end_block, // start: 250330,
-                           // end: 250331
+        end: l2_end_block, 
     };
+
     utils::setup_logger();
 
     dotenv::dotenv().ok();
 
     let prover = ProverClient::from_env();
     let (range_pk, range_vk) = prover.setup(RANGE_ELF);
-    let (_agg_pk, agg_vk) = prover.setup(AGG_ELF);
+    // let (_agg_pk, agg_vk) = prover.setup(AGG_ELF);
     let multi_block_vkey_u8 = u32_to_u8(range_vk.vk.hash_u32());
     let _range_vkey_commitment = B256::from(multi_block_vkey_u8);
-    let _agg_vkey_hash = B256::from_str(&agg_vk.bytes32()).unwrap();
-
+    // let _agg_vkey_hash = B256::from_str(&agg_vk.bytes32()).unwrap();
     let fetcher = match OPSuccinctDataFetcher::new_with_rollup_config(RunContext::Docker).await {
         Ok(f) => f,
         Err(e) => {
@@ -111,12 +109,18 @@ async fn main() -> Result<()> {
         .expect("saving proof failed");
 
     info!("saved proof to {}", proof_path);
+    drop(prover);
+    info!("sleeping for 10 seconds");
+    tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
+    info!("good morning");
+    let proof_path = "proofs/12500-12501.bin".to_string();
+
+    let (proofs, boot_infos) = load_aggregation_proof_data(proof_path);
+
+    info!("loaded saved proof");
 
     let prover = ProverClient::from_env();
     let (_, vkey) = prover.setup(RANGE_ELF);
-    let (proofs, boot_infos) = load_aggregation_proof_data(proof_path, &vkey);
-
-    info!("loaded saved proof");
 
     let header = fetcher.get_latest_l1_head_in_batch(&boot_infos).await?;
     let headers = fetcher
@@ -124,6 +128,7 @@ async fn main() -> Result<()> {
         .await?;
     let multi_block_vkey_u8 = u32_to_u8(vkey.vk.hash_u32());
     let multi_block_vkey_b256 = B256::from(multi_block_vkey_u8);
+
     // println!(
     //     "Range ELF Verification Key Commitment: {}",
     //     multi_block_vkey_b256
@@ -150,10 +155,7 @@ async fn main() -> Result<()> {
 /// Load the aggregation proof data.
 fn load_aggregation_proof_data(
     proof_path: String,
-    range_vkey: &SP1VerifyingKey,
 ) -> (Vec<SP1Proof>, Vec<BootInfoStruct>) {
-
-    let prover = ProverClient::builder().cpu().build();
 
     if fs::metadata(&proof_path).is_err() {
         panic!("Proof file not found: {}", proof_path);
@@ -161,10 +163,6 @@ fn load_aggregation_proof_data(
 
     let mut deserialized_proof =
         SP1ProofWithPublicValues::load(proof_path).expect("loading proof failed");
-
-    prover
-        .verify(&deserialized_proof, range_vkey)
-        .expect("proof verification failed");
 
     // The public values are the BootInfoStruct.
     let boot_info = deserialized_proof.public_values.read();

--- a/sigil/op-succinct/proposer/succinct/bin/server.rs
+++ b/sigil/op-succinct/proposer/succinct/bin/server.rs
@@ -28,12 +28,11 @@ use sp1_sdk::{
         FulfillmentStrategy,
     },
     utils, HashableKey, Prover, ProverClient, SP1Proof, SP1ProofMode, SP1ProofWithPublicValues,
-    SP1_CIRCUIT_VERSION,
+    SP1_CIRCUIT_VERSION, SP1Stdin, SP1ProvingKey, CudaProver
 };
-use std::{collections::HashMap, env, fmt::Display, str::FromStr, sync::Arc};
 use std::{
-    env, fs,
-    str::FromStr,
+    fs,
+    collections::HashMap, env, fmt::Display, str::FromStr, sync::Arc,
     time::{Instant, SystemTime, UNIX_EPOCH},
 };
 use tokio::sync::RwLock;

--- a/sigil/op-succinct/proposer/succinct/bin/server.rs
+++ b/sigil/op-succinct/proposer/succinct/bin/server.rs
@@ -516,24 +516,25 @@ async fn get_proof_status(
     };
 
     // Check the deadline.
-    if status.deadline
-        < SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs()
-    {
-        error!(
-            "Proof request timed out on the server. Default timeout is set to 4 hours. Returning status as Unfulfillable."
-        );
-        return Ok((
-            StatusCode::OK,
-            Json(ProofStatus {
-                fulfillment_status: FulfillmentStatus::Unfulfillable.into(),
-                execution_status: ExecutionStatus::Executed.into(),
-                proof: vec![],
-            }),
-        ));
-    }
+    // TODO: add back in 
+    // if status.deadline
+    //     < SystemTime::now()
+    //         .duration_since(UNIX_EPOCH)
+    //         .unwrap()
+    //         .as_secs()
+    // {
+    //     error!(
+    //         "Proof request timed out on the server. Default timeout is set to 4 hours. Returning status as Unfulfillable."
+    //     );
+    //     return Ok((
+    //         StatusCode::OK,
+    //         Json(ProofStatus {
+    //             fulfillment_status: FulfillmentStatus::Unfulfillable.into(),
+    //             execution_status: ExecutionStatus::Executed.into(),
+    //             proof: vec![],
+    //         }),
+    //     ));
+    // }
 
     let fulfillment_status = status.fulfillment_status;
     let execution_status = status.execution_status;

--- a/sigil/op-succinct/proposer/succinct/bin/server.rs
+++ b/sigil/op-succinct/proposer/succinct/bin/server.rs
@@ -23,18 +23,11 @@ use op_succinct_proposer::{
     SuccinctProposerConfig, ValidateConfigRequest, ValidateConfigResponse,
 };
 use sp1_sdk::{
-    network::{
-        proto::network::{ExecutionStatus, FulfillmentStatus},
-        FulfillmentStrategy,
-    },
-    utils, HashableKey, Prover, ProverClient, SP1Proof, SP1ProofMode, SP1ProofWithPublicValues,
-    SP1_CIRCUIT_VERSION, SP1Stdin, SP1ProvingKey, CudaProver
+    network::proto::network::{ExecutionStatus, FulfillmentStatus},
+    utils, CudaProver, HashableKey, Prover, ProverClient, SP1Proof, SP1ProofWithPublicValues,
+    SP1ProvingKey, SP1Stdin,
 };
-use std::{
-    fs,
-    collections::HashMap, env, fmt::Display, str::FromStr, sync::Arc,
-    time::{Instant, SystemTime, UNIX_EPOCH},
-};
+use std::{collections::HashMap, env, fmt::Display, str::FromStr, sync::Arc};
 use tokio::sync::RwLock;
 use tower_http::limit::RequestBodyLimitLayer;
 use uuid::Uuid;
@@ -67,16 +60,6 @@ async fn main() -> Result<()> {
 
     let proof_store = Arc::new(RwLock::new(HashMap::new()));
 
-    // Set the proof strategies based on environment variables. Default to reserved to keep existing behavior.
-    let range_proof_strategy = match env::var("RANGE_PROOF_STRATEGY") {
-        Ok(strategy) if strategy.to_lowercase() == "hosted" => FulfillmentStrategy::Hosted,
-        _ => FulfillmentStrategy::Reserved,
-    };
-    let agg_proof_strategy = match env::var("AGG_PROOF_STRATEGY") {
-        Ok(strategy) if strategy.to_lowercase() == "hosted" => FulfillmentStrategy::Hosted,
-        _ => FulfillmentStrategy::Reserved,
-    };
-
     // Initialize global hashes.
     let global_hashes = SuccinctProposerConfig {
         agg_vkey_hash,
@@ -88,8 +71,6 @@ async fn main() -> Result<()> {
         agg_pk,
         proof_store,
         prover_client,
-        range_proof_strategy,
-        agg_proof_strategy,
     };
 
     let app = Router::new()
@@ -488,8 +469,6 @@ async fn get_proof_status(
 ) -> Result<(StatusCode, Json<ProofStatus>), AppError> {
     info!("Received proof status request: {:?}", proof_id);
 
-    //let client = ProverClient::builder().network().build();
-
     let proof_id = hex::decode(proof_id)?;
 
     // request read-only copy of proof_store
@@ -501,7 +480,6 @@ async fn get_proof_status(
             ProofStatus {
                 fulfillment_status: proof_status.fulfillment_status,
                 execution_status: proof_status.execution_status,
-                // TODO: fix this clone
                 proof: proof_status.proof.clone(),
             }
         }
@@ -516,7 +494,7 @@ async fn get_proof_status(
     };
 
     // Check the deadline.
-    // TODO: add back in 
+    // TODO: add back in
     // if status.deadline
     //     < SystemTime::now()
     //         .duration_since(UNIX_EPOCH)
@@ -595,17 +573,29 @@ async fn send_proof(
         info!("computing {proof_type} proof with id {:?}", proof_id);
 
         let proof_res = match proof_type {
-            ProofType::Span => prover_client
-                .prove(&proving_key, &sp1_stdin)
-                .compressed()
-                .run(),
-            ProofType::Agg => prover_client
-                .prove(&proving_key, &sp1_stdin)
-                .groth16()
-                .run(),
+            ProofType::Span => {
+                // the cuda prover keeps state of the last `setup()` that was called on it.
+                // You must call `setup()` then `prove` *each* time you intend to
+                // prove a certain program
+                let _ = prover_client.setup(RANGE_ELF);
+                prover_client
+                    .prove(&proving_key, &sp1_stdin)
+                    .compressed()
+                    .run()
+            }
+            ProofType::Agg => {
+                // the cuda prover keeps state of the last `setup()` that was called on it.
+                // You must call `setup()` then `prove` *each* time you intend to
+                // prove a certain program
+                let _ = prover_client.setup(AGG_ELF);
+                prover_client
+                    .prove(&proving_key, &sp1_stdin)
+                    .groth16()
+                    .run()
+            }
         };
 
-        /*
+        /* FOR REFERENCE
         #[repr(i32)]
         pub enum ExecutionStatus {
             UnspecifiedExecutionStatus = 0,

--- a/sigil/op-succinct/proposer/succinct/src/lib.rs
+++ b/sigil/op-succinct/proposer/succinct/src/lib.rs
@@ -2,7 +2,7 @@ use alloy_primitives::B256;
 use base64::{engine::general_purpose, Engine as _};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use sp1_sdk::{network::FulfillmentStrategy, CudaProver, SP1ProvingKey, SP1VerifyingKey};
+use sp1_sdk::{CudaProver, SP1ProvingKey, SP1VerifyingKey};
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::RwLock;
 
@@ -92,11 +92,8 @@ pub struct SuccinctProposerConfig {
     pub agg_vkey_hash: B256,
     pub range_vkey_commitment: B256,
     pub rollup_config_hash: B256,
-    // state variables.  TODO: remove from ContractConfig
     pub proof_store: ProofStore,
     pub prover_client: Arc<CudaProver>,
-    pub range_proof_strategy: FulfillmentStrategy,
-    pub agg_proof_strategy: FulfillmentStrategy,
 }
 
 /// Deserialize a vector of base64 strings into a vector of vectors of bytes. Go serializes


### PR DESCRIPTION
- Running `prover.setup()` on each proof request in `bin/server.rs` (following advice of @nuhhtyy in `Sigil <> Succinct` telegram channel)

- Added an agg proof in `bin/minimal-server.rs`

