### PR TITLE
feat: fallback prover

### DIFF
--- a/sigil/op-succinct/Cargo.lock
+++ b/sigil/op-succinct/Cargo.lock
@@ -4142,6 +4142,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "op-succinct-fallback-proposer"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "anyhow",
+ "axum",
+ "base64 0.22.1",
+ "bincode",
+ "csv",
+ "dotenv",
+ "log",
+ "op-succinct-build-utils",
+ "op-succinct-client-utils",
+ "op-succinct-host-utils",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "sp1-sdk",
+ "tokio",
+ "tower-http",
+]
+
+[[package]]
 name = "op-succinct-fees"
 version = "0.1.0"
 dependencies = [

--- a/sigil/op-succinct/Cargo.lock
+++ b/sigil/op-succinct/Cargo.lock
@@ -4162,6 +4162,7 @@ dependencies = [
  "sp1-sdk",
  "tokio",
  "tower-http",
+ "uuid",
 ]
 
 [[package]]
@@ -7458,6 +7459,9 @@ name = "uuid"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
+dependencies = [
+ "getrandom 0.3.1",
+]
 
 [[package]]
 name = "valuable"

--- a/sigil/op-succinct/Cargo.lock
+++ b/sigil/op-succinct/Cargo.lock
@@ -297,6 +297,7 @@ dependencies = [
  "const-hex",
  "derive_more 2.0.1",
  "foldhash",
+ "getrandom 0.2.15",
  "hashbrown 0.15.2",
  "indexmap 2.7.1",
  "itoa",
@@ -4162,7 +4163,6 @@ dependencies = [
  "sp1-sdk",
  "tokio",
  "tower-http",
- "uuid",
 ]
 
 [[package]]
@@ -7459,9 +7459,6 @@ name = "uuid"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
-dependencies = [
- "getrandom 0.3.1",
-]
 
 [[package]]
 name = "valuable"

--- a/sigil/op-succinct/Cargo.toml
+++ b/sigil/op-succinct/Cargo.toml
@@ -1,5 +1,12 @@
 [workspace]
-members = ["utils/*", "programs/*", "scripts/*", "proposer/succinct", "fault_proof"]
+members = [
+	"utils/*",
+	"programs/*",
+	"scripts/*",
+	"proposer/succinct",
+	"fault_proof",
+	"proposer/op-succinct-fallback-proposer",
+]
 resolver = "2"
 
 [workspace.package]
@@ -44,8 +51,8 @@ kona-mpt = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-be
 kona-derive = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.9", default-features = false }
 kona-driver = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.9" }
 kona-preimage = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.9", features = [
-    "rkyv",
-    "serde",
+	"rkyv",
+	"serde",
 ] }
 kona-executor = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.9" }
 kona-proof = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.9" }
@@ -84,7 +91,7 @@ alloy-rpc-types-eth = { version = "0.11.0", default-features = false }
 
 # Keccak with the SHA3 patch is more efficient than the default Keccak.
 alloy-primitives = { version = "0.8.19", default-features = false, features = [
-    "sha3-keccak",
+	"sha3-keccak",
 ] }
 alloy-sol-types = { version = "0.8.19", default-features = false }
 alloy-sol-macro = { version = "0.8.19", default-features = false }
@@ -98,7 +105,7 @@ op-alloy-network = { version = "=0.10.3", default-features = false }
 # Maili
 maili-consensus = { version = "0.2.6", default-features = false }
 maili-rpc = { version = "0.2.6", default-features = false, features = [
-    "serde",
+	"serde",
 ] }
 maili-protocol = { version = "0.2.6", default-features = false }
 maili-registry = { version = "0.2.6", default-features = false }
@@ -127,3 +134,4 @@ substrate-bn = { git = "https://github.com/sp1-patches/bn", tag = "patch-0.6.0-s
 sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha3", tag = "patch-sha3-0.10.8-sp1-4.0.0" }
 p256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-p256-13.2-sp1-4.1.0" }
 k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-4.1.0" }
+

--- a/sigil/op-succinct/Cargo.toml
+++ b/sigil/op-succinct/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 	"scripts/*",
 	"proposer/succinct",
 	"fault_proof",
-	"proposer/op-succinct-fallback-proposer",
+	"proposer/fallback",
 ]
 resolver = "2"
 

--- a/sigil/op-succinct/proposer/fallback/Cargo.toml
+++ b/sigil/op-succinct/proposer/fallback/Cargo.toml
@@ -36,6 +36,7 @@ log.workspace = true
 base64.workspace = true
 tower-http.workspace = true
 serde_repr = "0.1.19"
+uuid = { version = "1.15.1", features = ["v4"] }
 
 [build-dependencies]
 op-succinct-build-utils.workspace = true

--- a/sigil/op-succinct/proposer/fallback/Cargo.toml
+++ b/sigil/op-succinct/proposer/fallback/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "op-succinct-fallback-proposer"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[[bin]]
+name = "fallback-server"
+path = "bin/server.rs"
+
+[dependencies]
+
+# workspace
+tokio.workspace = true
+alloy-primitives.workspace = true
+
+# local
+op-succinct-host-utils.workspace = true
+
+# sp1
+sp1-sdk.workspace = true
+
+anyhow.workspace = true
+dotenv.workspace = true
+op-succinct-client-utils.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+csv.workspace = true
+# server
+axum = "0.7.4"
+bincode.workspace = true
+log.workspace = true
+base64.workspace = true
+tower-http.workspace = true
+serde_repr = "0.1.19"
+
+[build-dependencies]
+op-succinct-build-utils.workspace = true

--- a/sigil/op-succinct/proposer/fallback/Cargo.toml
+++ b/sigil/op-succinct/proposer/fallback/Cargo.toml
@@ -15,7 +15,10 @@ path = "bin/server.rs"
 
 # workspace
 tokio.workspace = true
-alloy-primitives.workspace = true
+alloy-primitives = { workspace = true, features = [
+	"getrandom",
+] } #alloy-primitives.workspace = true
+
 
 # local
 op-succinct-host-utils.workspace = true
@@ -36,7 +39,6 @@ log.workspace = true
 base64.workspace = true
 tower-http.workspace = true
 serde_repr = "0.1.19"
-uuid = { version = "1.15.1", features = ["v4"] }
 
 [build-dependencies]
 op-succinct-build-utils.workspace = true

--- a/sigil/op-succinct/proposer/fallback/Dockerfile
+++ b/sigil/op-succinct/proposer/fallback/Dockerfile
@@ -1,0 +1,83 @@
+# syntax=docker/dockerfile:1.4
+
+# Build stage
+FROM ubuntu:24.04 AS builder
+
+WORKDIR /build
+
+# Install Rust and required dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    clang \
+    build-essential \
+    git \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH=/root/.cargo/bin:$PATH
+RUN rustup install nightly
+RUN rustup default nightly
+
+# Verify Rust installation
+RUN rustc --version && cargo --version
+
+# Install SP1
+RUN curl -L https://sp1.succinct.xyz | bash && \
+    ~/.sp1/bin/sp1up && \
+    ~/.sp1/bin/cargo-prove prove --version
+    
+# Copy only what's needed for the build
+COPY Cargo.toml Cargo.lock ./
+COPY proposer/succinct ./proposer/succinct
+COPY fault_proof ./fault_proof
+COPY elf ./elf
+COPY utils ./utils
+COPY programs ./programs
+COPY scripts ./scripts
+
+# Build the server
+RUN --mount=type=ssh \
+    --mount=type=cache,target=/root/.cargo/registry \
+    --mount=type=cache,target=/build/target \
+    cargo build --bin server --release && \
+    cp target/release/server /build/server
+
+# Final stage
+FROM ubuntu:24.04
+
+WORKDIR /app
+
+# Install Rust and required dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    clang \
+    build-essential \
+    git \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH=/root/.cargo/bin:$PATH
+RUN rustup install nightly
+RUN rustup default nightly
+
+# Verify Rust installation
+RUN rustc --version && cargo --version
+
+# Install SP1
+RUN curl -L https://sp1.succinct.xyz | bash && \
+    ~/.sp1/bin/sp1up && \
+    ~/.sp1/bin/cargo-prove prove --version
+
+# Copy only the built binaries from builder
+COPY --from=builder /build/server /usr/local/bin/server
+
+# Expose port based on environment variable or default to 3000
+ENV PORT=${PORT:-3000}
+EXPOSE $PORT
+
+# Run the server from its permanent location
+CMD ["/usr/local/bin/server"]

--- a/sigil/op-succinct/proposer/fallback/bin/server.rs
+++ b/sigil/op-succinct/proposer/fallback/bin/server.rs
@@ -216,46 +216,7 @@ async fn request_span_proof(
         }
     };
 
-    let proof_id = if state.local_proving_only {
-        send_proof(
-            ProofType::Span,
-            state.proof_store.clone(),
-            state.cuda_prover.clone(),
-            sp1_stdin,
-        )
-        .await?
-    } else {
-        // future producing closure
-        let network_proof_request = || {
-            state
-                .network_prover
-                .prove(&state.range_pk, &sp1_stdin)
-                .compressed()
-                .strategy(state.range_proof_strategy)
-                .skip_simulation(true)
-                .cycle_limit(1_000_000_000_000)
-                .request_async()
-        };
-
-        // request the future a number of times
-        match request_with_retries(state.prover_network_retries, network_proof_request).await {
-            Ok(proof_id) => proof_id,
-            Err(_) => {
-                error!(
-                    "Prover network request for span proof {} failed. Requesting proof locally.",
-                    payload
-                );
-
-                send_proof(
-                    ProofType::Span,
-                    state.proof_store.clone(),
-                    state.cuda_prover.clone(),
-                    sp1_stdin,
-                )
-                .await?
-            }
-        }
-    };
+    let proof_id = route_proof(ProofType::Span, &state, sp1_stdin).await?;
 
     Ok((
         StatusCode::OK,
@@ -354,41 +315,7 @@ async fn request_agg_proof(
             }
         };
 
-    let proof_id = if state.local_proving_only {
-        send_proof(
-            ProofType::Agg,
-            state.proof_store.clone(),
-            state.cuda_prover.clone(),
-            sp1_stdin,
-        )
-        .await?
-    } else {
-        // future producing closure
-        let network_proof_request = || {
-            state
-                .network_prover
-                .prove(&state.agg_pk, &sp1_stdin)
-                .mode(state.agg_proof_mode)
-                .strategy(state.agg_proof_strategy)
-                .request_async()
-        };
-
-        // request the future a number of times
-        match request_with_retries(state.prover_network_retries, network_proof_request).await {
-            Ok(proof_id) => proof_id,
-            Err(_) => {
-                error!("Prover network request to generate agg proof failed. Requesting proof locally.");
-
-                send_proof(
-                    ProofType::Agg,
-                    state.proof_store.clone(),
-                    state.cuda_prover.clone(),
-                    sp1_stdin,
-                )
-                .await?
-            }
-        }
-    };
+    let proof_id = route_proof(ProofType::Agg, &state, sp1_stdin).await?;
 
     Ok((
         StatusCode::OK,
@@ -779,10 +706,77 @@ async fn get_proof_status(
     ))
 }
 
+// if LOCAL_PROVING_ONLY is set to true, request a local proof
+// otherwise, make a request to the prover network.  If this request
+// fails PROVER_NETWORK_RETRIES times, then fall back to local proving
+async fn route_proof(
+    proof_type: ProofType,
+    state: &SuccinctProposerConfig,
+    sp1_stdin: SP1Stdin,
+) -> Result<B256, AppError> {
+    if state.local_proving_only {
+        locally_prove(
+            proof_type,
+            state.proof_store.clone(),
+            state.cuda_prover.clone(),
+            sp1_stdin,
+        )
+        .await
+    } else {
+        let prover_network_response = match proof_type {
+            ProofType::Span => {
+                let network_request = || {
+                    state
+                        .network_prover
+                        .prove(&state.range_pk, &sp1_stdin)
+                        .compressed()
+                        .strategy(state.range_proof_strategy)
+                        .skip_simulation(true)
+                        .cycle_limit(1_000_000_000_000)
+                        .request_async()
+                };
+                request_with_retries(state.prover_network_retries, network_request).await
+            }
+            ProofType::Agg => {
+                let network_request = || {
+                    state
+                        .network_prover
+                        .prove(&state.agg_pk, &sp1_stdin)
+                        .mode(state.agg_proof_mode)
+                        .strategy(state.agg_proof_strategy)
+                        .request_async()
+                };
+                request_with_retries(state.prover_network_retries, network_request).await
+            }
+        };
+
+        // request the future a number of times
+        match prover_network_response {
+            // success
+            Ok(proof_id) => Ok(proof_id),
+            // failed after PROVER_NETWORK_RETRIES retries, make the proof locally
+            Err(_) => {
+                error!(
+                    "Prover network request for {} proof failed. Requesting proof locally.",
+                    proof_type
+                );
+
+                locally_prove(
+                    proof_type,
+                    state.proof_store.clone(),
+                    state.cuda_prover.clone(),
+                    sp1_stdin,
+                )
+                .await
+            }
+        }
+    }
+}
+
 // spawns a process that creates a proof locally
 // runs proof in a background thread.  Only needs to be async because of
 // proof_store.write().await.  It isn't blocked by anything else.
-async fn send_proof(
+async fn locally_prove(
     proof_type: ProofType,
     proof_store: ProofStore,
     cuda_prover: Arc<CudaProver>,

--- a/sigil/op-succinct/proposer/fallback/bin/server.rs
+++ b/sigil/op-succinct/proposer/fallback/bin/server.rs
@@ -1,0 +1,637 @@
+use alloy_primitives::{hex, Address, B256};
+use anyhow::Result;
+use axum::{
+    extract::{DefaultBodyLimit, Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Json, Router,
+};
+use log::{error, info};
+use op_succinct_client_utils::{
+    boot::{hash_rollup_config, BootInfoStruct},
+    types::u32_to_u8,
+};
+use op_succinct_host_utils::{
+    fetcher::{CacheMode, OPSuccinctDataFetcher, RunContext},
+    get_agg_proof_stdin, get_proof_stdin, start_server_and_native_client,
+    stats::ExecutionStats,
+    L2OutputOracle, ProgramType,
+};
+use op_succinct_proposer::{
+    AggProofRequest, ProofResponse, ProofStatus, SpanProofRequest, SuccinctProposerConfig,
+    ValidateConfigRequest, ValidateConfigResponse,
+};
+use sp1_sdk::{
+    network::{
+        proto::network::{ExecutionStatus, FulfillmentStatus},
+        FulfillmentStrategy,
+    },
+    utils, HashableKey, Prover, ProverClient, SP1Proof, SP1ProofMode, SP1ProofWithPublicValues,
+    SP1_CIRCUIT_VERSION,
+};
+use std::{
+    env, fs,
+    str::FromStr,
+    sync::Arc,
+    time::{Instant, SystemTime, UNIX_EPOCH},
+};
+use tower_http::limit::RequestBodyLimitLayer;
+
+pub const RANGE_ELF: &[u8] = include_bytes!("../../../elf/range-elf");
+pub const AGG_ELF: &[u8] = include_bytes!("../../../elf/aggregation-elf");
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Enable logging.
+    env::set_var("RUST_LOG", "info");
+
+    // Set up the SP1 SDK logger.
+    utils::setup_logger();
+    dotenv::dotenv().ok();
+
+    let network_prover = Arc::new(ProverClient::builder().network().build());
+    let (range_pk, range_vk) = network_prover.setup(RANGE_ELF);
+    let (agg_pk, agg_vk) = network_prover.setup(AGG_ELF);
+    let multi_block_vkey_u8 = u32_to_u8(range_vk.vk.hash_u32());
+    let range_vkey_commitment = B256::from(multi_block_vkey_u8);
+    let agg_vkey_hash = B256::from_str(&agg_vk.bytes32()).unwrap();
+
+    let fetcher = OPSuccinctDataFetcher::new_with_rollup_config(RunContext::Docker).await?;
+    // Note: The rollup config hash never changes for a given chain, so we can just hash it once at
+    // server start-up. The only time a rollup config changes is typically when a new version of the
+    // [`RollupConfig`] is released from `op-alloy`.
+    let rollup_config_hash = hash_rollup_config(fetcher.rollup_config.as_ref().unwrap());
+
+    // Set the proof strategies based on environment variables. Default to reserved to keep existing behavior.
+    let range_proof_strategy = match env::var("RANGE_PROOF_STRATEGY") {
+        Ok(strategy) if strategy.to_lowercase() == "hosted" => FulfillmentStrategy::Hosted,
+        _ => FulfillmentStrategy::Reserved,
+    };
+    let agg_proof_strategy = match env::var("AGG_PROOF_STRATEGY") {
+        Ok(strategy) if strategy.to_lowercase() == "hosted" => FulfillmentStrategy::Hosted,
+        _ => FulfillmentStrategy::Reserved,
+    };
+
+    // Set the aggregation proof type based on environment variable. Default to groth16.
+    let agg_proof_mode = match env::var("AGG_PROOF_MODE") {
+        Ok(proof_type) if proof_type.to_lowercase() == "plonk" => SP1ProofMode::Plonk,
+        _ => SP1ProofMode::Groth16,
+    };
+
+    // Initialize global hashes.
+    let global_hashes = SuccinctProposerConfig {
+        agg_vkey_hash,
+        range_vkey_commitment,
+        rollup_config_hash,
+        range_vk: Arc::new(range_vk),
+        range_pk: Arc::new(range_pk),
+        agg_vk: Arc::new(agg_vk),
+        agg_pk: Arc::new(agg_pk),
+        range_proof_strategy,
+        agg_proof_strategy,
+        agg_proof_mode,
+        network_prover,
+    };
+
+    let app = Router::new()
+        .route("/request_span_proof", post(request_span_proof))
+        .route("/request_agg_proof", post(request_agg_proof))
+        .route("/request_mock_span_proof", post(request_mock_span_proof))
+        .route("/request_mock_agg_proof", post(request_mock_agg_proof))
+        .route("/status/:proof_id", get(get_proof_status))
+        .route("/validate_config", post(validate_config))
+        .layer(DefaultBodyLimit::disable())
+        .layer(RequestBodyLimitLayer::new(102400 * 1024 * 1024))
+        .with_state(global_hashes);
+
+    let port = env::var("PORT").unwrap_or_else(|_| "3000".to_string());
+    let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", port))
+        .await
+        .unwrap();
+
+    info!("Server listening on {}", listener.local_addr().unwrap());
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+/// Validate the configuration of the L2 Output Oracle.
+async fn validate_config(
+    State(state): State<SuccinctProposerConfig>,
+    Json(payload): Json<ValidateConfigRequest>,
+) -> Result<(StatusCode, Json<ValidateConfigResponse>), AppError> {
+    info!("Received validate config request: {:?}", payload);
+    let fetcher = OPSuccinctDataFetcher::default();
+
+    let address = Address::from_str(&payload.address).unwrap();
+    let l2_output_oracle = L2OutputOracle::new(address, fetcher.l1_provider);
+
+    let agg_vkey = l2_output_oracle.aggregationVkey().call().await?;
+    let range_vkey = l2_output_oracle.rangeVkeyCommitment().call().await?;
+    let rollup_config_hash = l2_output_oracle.rollupConfigHash().call().await?;
+
+    let agg_vkey_valid = agg_vkey.aggregationVkey == state.agg_vkey_hash;
+    let range_vkey_valid = range_vkey.rangeVkeyCommitment == state.range_vkey_commitment;
+    let rollup_config_hash_valid = rollup_config_hash.rollupConfigHash == state.rollup_config_hash;
+
+    Ok((
+        StatusCode::OK,
+        Json(ValidateConfigResponse {
+            rollup_config_hash_valid,
+            agg_vkey_valid,
+            range_vkey_valid,
+        }),
+    ))
+}
+
+/// Request a proof for a span of blocks.
+async fn request_span_proof(
+    State(state): State<SuccinctProposerConfig>,
+    Json(payload): Json<SpanProofRequest>,
+) -> Result<(StatusCode, Json<ProofResponse>), AppError> {
+    info!("Received span proof request: {:?}", payload);
+    let fetcher = match OPSuccinctDataFetcher::new_with_rollup_config(RunContext::Docker).await {
+        Ok(f) => f,
+        Err(e) => {
+            error!("Failed to create data fetcher: {}", e);
+            return Err(AppError(e));
+        }
+    };
+
+    let host_args = match fetcher
+        .get_host_args(
+            payload.start,
+            payload.end,
+            None,
+            ProgramType::Multi,
+            CacheMode::DeleteCache,
+        )
+        .await
+    {
+        Ok(cli) => cli,
+        Err(e) => {
+            error!("Failed to get host CLI args: {}", e);
+            return Err(AppError(anyhow::anyhow!(
+                "Failed to get host CLI args: {}",
+                e
+            )));
+        }
+    };
+
+    let mem_kv_store = start_server_and_native_client(host_args).await?;
+
+    let sp1_stdin = match get_proof_stdin(mem_kv_store) {
+        Ok(stdin) => stdin,
+        Err(e) => {
+            error!("Failed to get proof stdin: {}", e);
+            return Err(AppError(anyhow::anyhow!(
+                "Failed to get proof stdin: {}",
+                e
+            )));
+        }
+    };
+
+    let proof_id = state
+        .network_prover
+        .prove(&state.range_pk, &sp1_stdin)
+        .compressed()
+        .strategy(state.range_proof_strategy)
+        .skip_simulation(true)
+        .cycle_limit(1_000_000_000_000)
+        .request_async()
+        .await
+        .map_err(|e| {
+            error!("Failed to request proof: {}", e);
+            AppError(anyhow::anyhow!("Failed to request proof: {}", e))
+        })?;
+
+    Ok((
+        StatusCode::OK,
+        Json(ProofResponse {
+            proof_id: proof_id.to_vec(),
+        }),
+    ))
+}
+
+/// Request an aggregation proof for a set of subproofs.
+async fn request_agg_proof(
+    State(state): State<SuccinctProposerConfig>,
+    Json(payload): Json<AggProofRequest>,
+) -> Result<(StatusCode, Json<ProofResponse>), AppError> {
+    info!("Received agg proof request");
+    let mut proofs_with_pv: Vec<SP1ProofWithPublicValues> = payload
+        .subproofs
+        .iter()
+        .map(|sp| bincode::deserialize(sp).unwrap())
+        .collect();
+
+    let boot_infos: Vec<BootInfoStruct> = proofs_with_pv
+        .iter_mut()
+        .map(|proof| proof.public_values.read())
+        .collect();
+
+    let proofs: Vec<SP1Proof> = proofs_with_pv
+        .iter_mut()
+        .map(|proof| proof.proof.clone())
+        .collect();
+
+    let l1_head_bytes = match payload.head.strip_prefix("0x") {
+        Some(hex_str) => match hex::decode(hex_str) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                error!("Failed to decode L1 head hex string: {}", e);
+                return Err(AppError(anyhow::anyhow!(
+                    "Failed to decode L1 head hex string: {}",
+                    e
+                )));
+            }
+        },
+        None => {
+            error!("Invalid L1 head format: missing 0x prefix");
+            return Err(AppError(anyhow::anyhow!(
+                "Invalid L1 head format: missing 0x prefix"
+            )));
+        }
+    };
+
+    let l1_head: [u8; 32] = match l1_head_bytes.clone().try_into() {
+        Ok(array) => array,
+        Err(_) => {
+            error!(
+                "Invalid L1 head length: expected 32 bytes, got {}",
+                l1_head_bytes.len()
+            );
+            return Err(AppError(anyhow::anyhow!(
+                "Invalid L1 head length: expected 32 bytes, got {}",
+                l1_head_bytes.len()
+            )));
+        }
+    };
+
+    let fetcher = match OPSuccinctDataFetcher::new_with_rollup_config(RunContext::Docker).await {
+        Ok(f) => f,
+        Err(e) => {
+            error!("Failed to create fetcher: {}", e);
+            return Err(AppError(anyhow::anyhow!("Failed to create fetcher: {}", e)));
+        }
+    };
+
+    let headers = match fetcher
+        .get_header_preimages(&boot_infos, l1_head.into())
+        .await
+    {
+        Ok(h) => h,
+        Err(e) => {
+            error!("Failed to get header preimages: {}", e);
+            return Err(AppError(anyhow::anyhow!(
+                "Failed to get header preimages: {}",
+                e
+            )));
+        }
+    };
+
+    let stdin =
+        match get_agg_proof_stdin(proofs, boot_infos, headers, &state.range_vk, l1_head.into()) {
+            Ok(s) => s,
+            Err(e) => {
+                error!("Failed to get agg proof stdin: {}", e);
+                return Err(AppError(anyhow::anyhow!(
+                    "Failed to get agg proof stdin: {}",
+                    e
+                )));
+            }
+        };
+
+    let proof_id = match state
+        .network_prover
+        .prove(&state.agg_pk, &stdin)
+        .mode(state.agg_proof_mode)
+        .strategy(state.agg_proof_strategy)
+        .request_async()
+        .await
+    {
+        Ok(id) => id,
+        Err(e) => {
+            error!("Failed to request proof: {}", e);
+            return Err(AppError(anyhow::anyhow!("Failed to request proof: {}", e)));
+        }
+    };
+
+    Ok((
+        StatusCode::OK,
+        Json(ProofResponse {
+            proof_id: proof_id.to_vec(),
+        }),
+    ))
+}
+
+/// Request a mock proof for a span of blocks.
+async fn request_mock_span_proof(
+    State(state): State<SuccinctProposerConfig>,
+    Json(payload): Json<SpanProofRequest>,
+) -> Result<(StatusCode, Json<ProofStatus>), AppError> {
+    info!("Received mock span proof request: {:?}", payload);
+    let fetcher = match OPSuccinctDataFetcher::new_with_rollup_config(RunContext::Docker).await {
+        Ok(f) => f,
+        Err(e) => {
+            error!("Failed to create data fetcher: {}", e);
+            return Err(AppError(e));
+        }
+    };
+
+    let host_args = match fetcher
+        .get_host_args(
+            payload.start,
+            payload.end,
+            None,
+            ProgramType::Multi,
+            CacheMode::DeleteCache,
+        )
+        .await
+    {
+        Ok(cli) => cli,
+        Err(e) => {
+            error!("Failed to get host CLI args: {}", e);
+            return Err(AppError(e));
+        }
+    };
+
+    let start_time = Instant::now();
+    let oracle = start_server_and_native_client(host_args.clone()).await?;
+    let witness_generation_duration = start_time.elapsed();
+
+    let sp1_stdin = match get_proof_stdin(oracle) {
+        Ok(stdin) => stdin,
+        Err(e) => {
+            error!("Failed to get proof stdin: {}", e);
+            return Err(AppError(e));
+        }
+    };
+
+    let start_time = Instant::now();
+
+    // Note(ratan): In a future version of the server which only supports mock proofs, Arc<MockProver> should be used to reduce memory usage.
+    let prover = ProverClient::builder().mock().build();
+    let (pv, report) = prover.execute(RANGE_ELF, &sp1_stdin).run().unwrap();
+    let execution_duration = start_time.elapsed();
+
+    let block_data = fetcher
+        .get_l2_block_data_range(payload.start, payload.end)
+        .await?;
+
+    let l1_head = host_args.kona_args.l1_head;
+    // Get the L1 block number from the L1 head.
+    let l1_block_number = fetcher.get_l1_header(l1_head.into()).await?.number;
+    let stats = ExecutionStats::new(
+        l1_block_number,
+        &block_data,
+        &report,
+        witness_generation_duration.as_secs(),
+        execution_duration.as_secs(),
+    );
+
+    let l2_chain_id = fetcher.get_l2_chain_id().await?;
+    // Save the report to disk.
+    let report_dir = format!("execution-reports/{}", l2_chain_id);
+    if !std::path::Path::new(&report_dir).exists() {
+        fs::create_dir_all(&report_dir)?;
+    }
+
+    let report_path = format!("{}/{}-{}.json", report_dir, payload.start, payload.end);
+    // Write to CSV.
+    let mut csv_writer = csv::Writer::from_path(report_path)?;
+    csv_writer.serialize(&stats)?;
+    csv_writer.flush()?;
+
+    let proof = SP1ProofWithPublicValues::create_mock_proof(
+        &state.range_pk,
+        pv.clone(),
+        SP1ProofMode::Compressed,
+        SP1_CIRCUIT_VERSION,
+    );
+
+    let proof_bytes = bincode::serialize(&proof).unwrap();
+
+    Ok((
+        StatusCode::OK,
+        Json(ProofStatus {
+            fulfillment_status: FulfillmentStatus::Fulfilled.into(),
+            execution_status: ExecutionStatus::UnspecifiedExecutionStatus.into(),
+            proof: proof_bytes,
+        }),
+    ))
+}
+
+/// Request mock aggregation proof.
+async fn request_mock_agg_proof(
+    State(state): State<SuccinctProposerConfig>,
+    Json(payload): Json<AggProofRequest>,
+) -> Result<(StatusCode, Json<ProofStatus>), AppError> {
+    info!("Received mock agg proof request!");
+
+    let mut proofs_with_pv: Vec<SP1ProofWithPublicValues> = payload
+        .subproofs
+        .iter()
+        .map(|sp| bincode::deserialize(sp).unwrap())
+        .collect();
+
+    let boot_infos: Vec<BootInfoStruct> = proofs_with_pv
+        .iter_mut()
+        .map(|proof| proof.public_values.read())
+        .collect();
+
+    let proofs: Vec<SP1Proof> = proofs_with_pv
+        .iter_mut()
+        .map(|proof| proof.proof.clone())
+        .collect();
+
+    let l1_head_bytes = match hex::decode(
+        payload
+            .head
+            .strip_prefix("0x")
+            .expect("Invalid L1 head, no 0x prefix."),
+    ) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            error!("Failed to decode L1 head: {}", e);
+            return Err(AppError(anyhow::anyhow!("Failed to decode L1 head: {}", e)));
+        }
+    };
+    let l1_head: [u8; 32] = l1_head_bytes.try_into().unwrap();
+
+    let fetcher = match OPSuccinctDataFetcher::new_with_rollup_config(RunContext::Docker).await {
+        Ok(f) => f,
+        Err(e) => {
+            error!("Failed to create data fetcher: {}", e);
+            return Err(AppError(e));
+        }
+    };
+    let headers = match fetcher
+        .get_header_preimages(&boot_infos, l1_head.into())
+        .await
+    {
+        Ok(h) => h,
+        Err(e) => {
+            error!("Failed to get header preimages: {}", e);
+            return Err(AppError(e));
+        }
+    };
+
+    let stdin =
+        match get_agg_proof_stdin(proofs, boot_infos, headers, &state.range_vk, l1_head.into()) {
+            Ok(s) => s,
+            Err(e) => {
+                error!("Failed to get aggregation proof stdin: {}", e);
+                return Err(AppError(e));
+            }
+        };
+
+    // Note(ratan): In a future version of the server which only supports mock proofs, Arc<MockProver> should be used to reduce memory usage.
+    let prover = ProverClient::builder().mock().build();
+    let proof = match prover
+        .prove(&state.agg_pk, &stdin)
+        .mode(state.agg_proof_mode)
+        .deferred_proof_verification(false)
+        .run()
+    {
+        Ok(p) => p,
+        Err(e) => {
+            error!("Failed to generate proof: {}", e);
+            return Err(AppError(e));
+        }
+    };
+
+    Ok((
+        StatusCode::OK,
+        Json(ProofStatus {
+            fulfillment_status: FulfillmentStatus::Fulfilled.into(),
+            execution_status: ExecutionStatus::UnspecifiedExecutionStatus.into(),
+            proof: proof.bytes(),
+        }),
+    ))
+}
+
+/// Get the status of a proof.
+async fn get_proof_status(
+    State(state): State<SuccinctProposerConfig>,
+    Path(proof_id): Path<String>,
+) -> Result<(StatusCode, Json<ProofStatus>), AppError> {
+    info!("Received proof status request: {:?}", proof_id);
+
+    let proof_id_bytes = hex::decode(proof_id)?;
+
+    // This request will time out if the server is down.
+    let (status, maybe_proof) = match state
+        .network_prover
+        .get_proof_status(B256::from_slice(&proof_id_bytes))
+        .await
+    {
+        Ok(res) => res,
+        Err(e) => {
+            error!("Failed to get proof status: {}", e);
+            return Err(AppError(e));
+        }
+    };
+
+    // Check the deadline.
+    if status.deadline
+        < SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    {
+        error!(
+            "Proof request timed out on the server. Default timeout is set to 4 hours. Returning status as Unfulfillable."
+        );
+        return Ok((
+            StatusCode::OK,
+            Json(ProofStatus {
+                fulfillment_status: FulfillmentStatus::Unfulfillable.into(),
+                execution_status: ExecutionStatus::Executed.into(),
+                proof: vec![],
+            }),
+        ));
+    }
+
+    let fulfillment_status = status.fulfillment_status;
+    let execution_status = status.execution_status;
+    if fulfillment_status == FulfillmentStatus::Fulfilled as i32 {
+        let proof: SP1ProofWithPublicValues = maybe_proof.unwrap();
+
+        match proof.proof {
+            SP1Proof::Compressed(_) => {
+                // If it's a compressed proof, we need to serialize the entire struct with bincode.
+                // Note: We're re-serializing the entire struct with bincode here, but this is fine
+                // because we're on localhost and the size of the struct is small.
+                let proof_bytes = bincode::serialize(&proof).unwrap();
+                return Ok((
+                    StatusCode::OK,
+                    Json(ProofStatus {
+                        fulfillment_status,
+                        execution_status,
+                        proof: proof_bytes,
+                    }),
+                ));
+            }
+            SP1Proof::Groth16(_) => {
+                // If it's a groth16 proof, we need to get the proof bytes that we put on-chain.
+                let proof_bytes = proof.bytes();
+                return Ok((
+                    StatusCode::OK,
+                    Json(ProofStatus {
+                        fulfillment_status,
+                        execution_status,
+                        proof: proof_bytes,
+                    }),
+                ));
+            }
+            SP1Proof::Plonk(_) => {
+                // If it's a plonk proof, we need to get the proof bytes that we put on-chain.
+                let proof_bytes = proof.bytes();
+                return Ok((
+                    StatusCode::OK,
+                    Json(ProofStatus {
+                        fulfillment_status,
+                        execution_status,
+                        proof: proof_bytes,
+                    }),
+                ));
+            }
+            _ => (),
+        }
+    } else if fulfillment_status == FulfillmentStatus::Unfulfillable as i32 {
+        return Ok((
+            StatusCode::OK,
+            Json(ProofStatus {
+                fulfillment_status,
+                execution_status,
+                proof: vec![],
+            }),
+        ));
+    }
+    Ok((
+        StatusCode::OK,
+        Json(ProofStatus {
+            fulfillment_status,
+            execution_status,
+            proof: vec![],
+        }),
+    ))
+}
+
+pub struct AppError(anyhow::Error);
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        (StatusCode::INTERNAL_SERVER_ERROR, format!("{}", self.0)).into_response()
+    }
+}
+
+impl<E> From<E> for AppError
+where
+    E: Into<anyhow::Error>,
+{
+    fn from(err: E) -> Self {
+        Self(err.into())
+    }
+}

--- a/sigil/op-succinct/proposer/fallback/bin/server.rs
+++ b/sigil/op-succinct/proposer/fallback/bin/server.rs
@@ -42,7 +42,6 @@ use tokio::{
     time::{error::Elapsed, timeout, Duration},
 };
 use tower_http::limit::RequestBodyLimitLayer;
-use uuid::Uuid;
 
 pub const RANGE_ELF: &[u8] = include_bytes!("../../../elf/range-elf");
 pub const AGG_ELF: &[u8] = include_bytes!("../../../elf/aggregation-elf");
@@ -708,7 +707,7 @@ async fn send_proof(
     proving_key: SP1ProvingKey,
     sp1_stdin: SP1Stdin,
 ) -> Result<B256, AppError> {
-    let proof_id = uuid_to_hex_bytes(Uuid::new_v4());
+    let proof_id = B256::random();
     let proof_id_clone = proof_id.clone();
 
     let initial_status = ProofStatus {
@@ -828,10 +827,6 @@ async fn send_proof(
     });
 
     Ok(proof_id_clone)
-}
-
-fn uuid_to_hex_bytes(uuid: Uuid) -> Vec<u8> {
-    format!("0x{:016x}", uuid.as_u128() >> 64).into_bytes()
 }
 
 pub struct AppError(anyhow::Error);

--- a/sigil/op-succinct/proposer/fallback/bin/server.rs
+++ b/sigil/op-succinct/proposer/fallback/bin/server.rs
@@ -241,7 +241,10 @@ async fn request_span_proof(
         match request_with_retries(state.prover_network_retries, network_proof_request).await {
             Ok(proof_id) => proof_id,
             Err(_) => {
-                error!("Prover network request failed. Requesting proof locally.");
+                error!(
+                    "Prover network request for span proof {} failed. Requesting proof locally.",
+                    payload
+                );
 
                 send_proof(
                     ProofType::Span,
@@ -374,7 +377,7 @@ async fn request_agg_proof(
         match request_with_retries(state.prover_network_retries, network_proof_request).await {
             Ok(proof_id) => proof_id,
             Err(_) => {
-                error!("Prover network request failed. Requesting proof locally.");
+                error!("Prover network request to generate agg proof failed. Requesting proof locally.");
 
                 send_proof(
                     ProofType::Agg,
@@ -589,20 +592,67 @@ async fn get_proof_status(
 ) -> Result<(StatusCode, Json<ProofStatus>), AppError> {
     info!("Received proof status request: {:?}", proof_id);
 
-    let proof_id_bytes = hex::decode(proof_id)?;
+    let proof_id_bytes = hex::decode(&proof_id)?;
+    let proof_id = B256::from_slice(&proof_id_bytes);
 
-    // This request will time out if the server is down.
-    let (status, maybe_proof) = match state
-        .network_prover
-        .get_proof_status(B256::from_slice(&proof_id_bytes))
-        .await
+    let network_proof_status_request = || state.network_prover.get_proof_status(proof_id);
+
+    // try to get the proof status, returning a failure to the proposer if it seems that the prover
+    // network is down
+    let (status, maybe_proof) = match request_with_retries(
+        state.prover_network_retries,
+        network_proof_status_request,
+    )
+    .await
     {
         Ok(res) => res,
-        Err(e) => {
-            error!("Failed to get proof status: {}", e);
-            return Err(AppError(e));
+        Err(_) => {
+            error!(
+                "Prover network request for status of proof {} failed",
+                proof_id
+            );
+
+            // When the proposer sees a FulfillmentStatus of Unfulfillable it will retry the proof
+            // request.  If the prover network is really down, the new request will fail inside
+            // `request_agg/span_proof()` and will be re-routed as a local proof
+            return Ok((
+                StatusCode::OK,
+                Json(ProofStatus {
+                    fulfillment_status: FulfillmentStatus::Unfulfillable.into(),
+                    // if execution status is also `Unexecutable`, then the retry proof request
+                    // will be half the block size.  This keeps the request the same
+                    execution_status: ExecutionStatus::UnspecifiedExecutionStatus.into(),
+                    proof: vec![],
+                }),
+            ));
         }
     };
+
+    /* FOR REFERENCE
+    #[repr(i32)]
+    pub enum ExecutionStatus {
+        UnspecifiedExecutionStatus = 0,
+        /// The request has not been executed.
+        Unexecuted = 1,
+        /// The request has been executed.
+        Executed = 2,
+        /// The request cannot be executed.
+        Unexecutable = 3,
+    }
+
+    #[repr(i32)]
+    pub enum FulfillmentStatus {
+        UnspecifiedFulfillmentStatus = 0,
+        /// The request has been requested.
+        Requested = 1,
+        /// The request has been assigned to a fulfiller.
+        Assigned = 2,
+        /// The request has been fulfilled.
+        Fulfilled = 3,
+        /// The request cannot be fulfilled.
+        Unfulfillable = 4,
+    }
+    * */
 
     // Check the deadline.
     if status.deadline
@@ -702,8 +752,8 @@ async fn send_proof(
     let proof_id = B256::random();
 
     let initial_status = ProofStatus {
-        fulfillment_status: 2,
-        execution_status: 1,
+        fulfillment_status: FulfillmentStatus::Assigned.into(),
+        execution_status: ExecutionStatus::Unexecuted.into(),
         proof: Vec::new(),
     };
 
@@ -733,32 +783,6 @@ async fn send_proof(
             }
         };
 
-        /* FOR REFERENCE
-        #[repr(i32)]
-        pub enum ExecutionStatus {
-            UnspecifiedExecutionStatus = 0,
-            /// The request has not been executed.
-            Unexecuted = 1,
-            /// The request has been executed.
-            Executed = 2,
-            /// The request cannot be executed.
-            Unexecutable = 3,
-        }
-
-        #[repr(i32)]
-        pub enum FulfillmentStatus {
-            UnspecifiedFulfillmentStatus = 0,
-            /// The request has been requested.
-            Requested = 1,
-            /// The request has been assigned to a fulfiller.
-            Assigned = 2,
-            /// The request has been fulfilled.
-            Fulfilled = 3,
-            /// The request cannot be fulfilled.
-            Unfulfillable = 4,
-        }
-        * */
-
         let proof_status = match proof_res {
             // proof is done, can return it
             Ok(proof) => {
@@ -769,8 +793,8 @@ async fn send_proof(
                         // because we're on localhost and the size of the struct is small.
                         let proof_bytes = bincode::serialize(&proof).unwrap();
                         ProofStatus {
-                            fulfillment_status: 3,
-                            execution_status: 2,
+                            fulfillment_status: FulfillmentStatus::Fulfilled.into(),
+                            execution_status: ExecutionStatus::Executed.into(),
                             proof: proof_bytes,
                         }
                     }
@@ -778,8 +802,8 @@ async fn send_proof(
                         // If it's a groth16 proof, we need to get the proof bytes that we put on-chain.
                         let proof_bytes = proof.bytes();
                         ProofStatus {
-                            fulfillment_status: 3,
-                            execution_status: 2,
+                            fulfillment_status: FulfillmentStatus::Fulfilled.into(),
+                            execution_status: ExecutionStatus::Executed.into(),
                             proof: proof_bytes,
                         }
                     }
@@ -787,8 +811,8 @@ async fn send_proof(
                         // If it's a plonk proof, we need to get the proof bytes that we put on-chain.
                         let proof_bytes = proof.bytes();
                         ProofStatus {
-                            fulfillment_status: 3,
-                            execution_status: 2,
+                            fulfillment_status: FulfillmentStatus::Fulfilled.into(),
+                            execution_status: ExecutionStatus::Executed.into(),
                             proof: proof_bytes,
                         }
                     }

--- a/sigil/op-succinct/proposer/fallback/bin/server.rs
+++ b/sigil/op-succinct/proposer/fallback/bin/server.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::{hex, Address, B256};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use axum::{
     extract::{DefaultBodyLimit, Path, State},
     http::StatusCode,
@@ -7,10 +7,14 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use log::{error, info};
+use log::{error, info, warn};
 use op_succinct_client_utils::{
     boot::{hash_rollup_config, BootInfoStruct},
     types::u32_to_u8,
+};
+use op_succinct_fallback_proposer::{
+    AggProofRequest, ProofResponse, ProofStatus, ProofStore, ProofType, SpanProofRequest,
+    SuccinctProposerConfig, ValidateConfigRequest, ValidateConfigResponse,
 };
 use op_succinct_host_utils::{
     fetcher::{CacheMode, OPSuccinctDataFetcher, RunContext},
@@ -18,25 +22,27 @@ use op_succinct_host_utils::{
     stats::ExecutionStats,
     L2OutputOracle, ProgramType,
 };
-use op_succinct_proposer::{
-    AggProofRequest, ProofResponse, ProofStatus, SpanProofRequest, SuccinctProposerConfig,
-    ValidateConfigRequest, ValidateConfigResponse,
-};
 use sp1_sdk::{
     network::{
         proto::network::{ExecutionStatus, FulfillmentStatus},
         FulfillmentStrategy,
     },
-    utils, HashableKey, Prover, ProverClient, SP1Proof, SP1ProofMode, SP1ProofWithPublicValues,
-    SP1_CIRCUIT_VERSION,
+    utils, CudaProver, HashableKey, NetworkProver, Prover, ProverClient, SP1Proof, SP1ProofMode,
+    SP1ProofWithPublicValues, SP1ProvingKey, SP1Stdin, SP1_CIRCUIT_VERSION,
 };
 use std::{
+    collections::HashMap,
     env, fs,
     str::FromStr,
     sync::Arc,
     time::{Instant, SystemTime, UNIX_EPOCH},
 };
+use tokio::{
+    sync::RwLock,
+    time::{error::Elapsed, timeout, Duration},
+};
 use tower_http::limit::RequestBodyLimitLayer;
+use uuid::Uuid;
 
 pub const RANGE_ELF: &[u8] = include_bytes!("../../../elf/range-elf");
 pub const AGG_ELF: &[u8] = include_bytes!("../../../elf/aggregation-elf");
@@ -50,12 +56,17 @@ async fn main() -> Result<()> {
     utils::setup_logger();
     dotenv::dotenv().ok();
 
+    // network prover setup
     let network_prover = Arc::new(ProverClient::builder().network().build());
     let (range_pk, range_vk) = network_prover.setup(RANGE_ELF);
     let (agg_pk, agg_vk) = network_prover.setup(AGG_ELF);
     let multi_block_vkey_u8 = u32_to_u8(range_vk.vk.hash_u32());
     let range_vkey_commitment = B256::from(multi_block_vkey_u8);
     let agg_vkey_hash = B256::from_str(&agg_vk.bytes32()).unwrap();
+
+    // local cuda prover setup for fallback
+    let cuda_prover = Arc::new(ProverClient::builder().cuda().build());
+    let proof_store = Arc::new(RwLock::new(HashMap::new()));
 
     let fetcher = OPSuccinctDataFetcher::new_with_rollup_config(RunContext::Docker).await?;
     // Note: The rollup config hash never changes for a given chain, so we can just hash it once at
@@ -79,6 +90,23 @@ async fn main() -> Result<()> {
         _ => SP1ProofMode::Groth16,
     };
 
+    // defaults to false, but can be set to true to never make succinct prover network requests
+    let local_proving_only = match env::var("LOCAL_PROVING_ONLY") {
+        Ok(on) if on.to_lowercase() == "true" => true,
+        _ => false,
+    };
+
+    // defaults to 4 mins
+    let network_timeout_duration_secs = match env::var("NETWORK_TIMEOUT_DURATION_SECS") {
+        Ok(secs) => {
+            let secs: u64 = secs
+                .parse()
+                .context("parsing env var NETWORK_TIMEOUT_DURATION_SECS as u64")?;
+            Duration::from_secs(secs)
+        }
+        _ => Duration::from_secs(4 * 60),
+    };
+
     // Initialize global hashes.
     let global_hashes = SuccinctProposerConfig {
         agg_vkey_hash,
@@ -92,6 +120,10 @@ async fn main() -> Result<()> {
         agg_proof_strategy,
         agg_proof_mode,
         network_prover,
+        network_timeout_duration_secs,
+        proof_store,
+        cuda_prover,
+        local_proving_only,
     };
 
     let app = Router::new()
@@ -191,19 +223,38 @@ async fn request_span_proof(
         }
     };
 
-    let proof_id = state
-        .network_prover
-        .prove(&state.range_pk, &sp1_stdin)
-        .compressed()
-        .strategy(state.range_proof_strategy)
-        .skip_simulation(true)
-        .cycle_limit(1_000_000_000_000)
-        .request_async()
+    let proof_id = if state.local_proving_only {
+        todo!()
+        // send_proof(
+        //     ProofType::Span,
+        //     state.proof_store.clone(),
+        //     state.cuda_prover.clone(),
+        //     state.range_pk,
+        //     sp1_stdin,
+        // )
+        // .await?
+    } else {
+        match request_network_proof_with_timeout(
+            state.network_prover.clone(),
+            state.range_pk,
+            state.range_proof_strategy,
+            state.network_timeout_duration_secs,
+            &sp1_stdin,
+        )
         .await
-        .map_err(|e| {
-            error!("Failed to request proof: {}", e);
-            AppError(anyhow::anyhow!("Failed to request proof: {}", e))
-        })?;
+        {
+            Ok(network_response) => network_response.map_err(|e| {
+                error!("Failed to request proof: {}", e);
+                AppError(anyhow::anyhow!("Failed to request proof: {}", e))
+            })?,
+            // TODO: this can be errors other than timeout, fix it
+            Err(timeout) => {
+                // TODO: local proof req
+                warn!("Reached timeout before getting a response from prover network: {timeout}. Requesting proof locally.");
+                todo!()
+            }
+        }
+    };
 
     Ok((
         StatusCode::OK,
@@ -512,6 +563,7 @@ async fn request_mock_agg_proof(
 }
 
 /// Get the status of a proof.
+// TODO: request proof locally if we get 3 failures on hitting prover network
 async fn get_proof_status(
     State(state): State<SuccinctProposerConfig>,
     Path(proof_id): Path<String>,
@@ -617,6 +669,169 @@ async fn get_proof_status(
             proof: vec![],
         }),
     ))
+}
+
+// Sends a proof request to the prover network and times out if no response is
+// heard within the timeout period
+// TODO: make this work for agg proofs too
+async fn request_network_proof_with_timeout(
+    network_prover: Arc<NetworkProver>,
+    range_pk: Arc<SP1ProvingKey>,
+    range_proof_strategy: FulfillmentStrategy,
+    timeout_duration_secs: Duration,
+    sp1_stdin: &SP1Stdin,
+) -> Result<Result<B256>, Elapsed> {
+    timeout(
+        timeout_duration_secs,
+        network_prover
+            .prove(&range_pk, sp1_stdin)
+            .compressed()
+            .strategy(range_proof_strategy)
+            .skip_simulation(true)
+            .cycle_limit(1_000_000_000_000)
+            .request_async(), // .await
+                              // .map_err(|e| {
+                              //     error!("Failed to request proof: {}", e);
+                              //     AppError(anyhow::anyhow!("Failed to request proof: {}", e))
+                              // })?,
+    )
+    .await
+}
+
+// spawns a process that creates a proof locally
+// runs proof in a background thread.  Only needs to be async because of
+// proof_store.write().await.  It isn't blocked by anything else.
+async fn send_proof(
+    proof_type: ProofType,
+    proof_store: ProofStore,
+    cuda_prover: Arc<CudaProver>,
+    proving_key: SP1ProvingKey,
+    sp1_stdin: SP1Stdin,
+) -> Result<B256, AppError> {
+    let proof_id = uuid_to_hex_bytes(Uuid::new_v4());
+    let proof_id_clone = proof_id.clone();
+
+    let initial_status = ProofStatus {
+        fulfillment_status: 2,
+        execution_status: 1,
+        proof: Vec::new(),
+    };
+
+    proof_store
+        .write()
+        .await
+        .insert(proof_id.clone(), initial_status);
+
+    tokio::spawn(async move {
+        let start_time = tokio::time::Instant::now();
+        info!("computing {proof_type} proof with id {:?}", proof_id);
+
+        let proof_res = match proof_type {
+            ProofType::Span => {
+                // the cuda prover keeps state of the last `setup()` that was called on it.
+                // You must call `setup()` then `prove` *each* time you intend to
+                // prove a certain program
+                let _ = cuda_prover.setup(RANGE_ELF);
+                cuda_prover
+                    .prove(&proving_key, &sp1_stdin)
+                    .compressed()
+                    .run()
+            }
+            ProofType::Agg => {
+                // the cuda prover keeps state of the last `setup()` that was called on it.
+                // You must call `setup()` then `prove` *each* time you intend to
+                // prove a certain program
+                let _ = cuda_prover.setup(AGG_ELF);
+                cuda_prover.prove(&proving_key, &sp1_stdin).groth16().run()
+            }
+        };
+
+        /* FOR REFERENCE
+        #[repr(i32)]
+        pub enum ExecutionStatus {
+            UnspecifiedExecutionStatus = 0,
+            /// The request has not been executed.
+            Unexecuted = 1,
+            /// The request has been executed.
+            Executed = 2,
+            /// The request cannot be executed.
+            Unexecutable = 3,
+        }
+
+        #[repr(i32)]
+        pub enum FulfillmentStatus {
+            UnspecifiedFulfillmentStatus = 0,
+            /// The request has been requested.
+            Requested = 1,
+            /// The request has been assigned to a fulfiller.
+            Assigned = 2,
+            /// The request has been fulfilled.
+            Fulfilled = 3,
+            /// The request cannot be fulfilled.
+            Unfulfillable = 4,
+        }
+        * */
+
+        let proof_status = match proof_res {
+            // proof is done, can return it
+            Ok(proof) => {
+                match proof.proof {
+                    SP1Proof::Compressed(_) => {
+                        // If it's a compressed proof, we need to serialize the entire struct with bincode.
+                        // Note: We're re-serializing the entire struct with bincode here, but this is fine
+                        // because we're on localhost and the size of the struct is small.
+                        let proof_bytes = bincode::serialize(&proof).unwrap();
+                        ProofStatus {
+                            fulfillment_status: 3,
+                            execution_status: 2,
+                            proof: proof_bytes,
+                        }
+                    }
+                    SP1Proof::Groth16(_) => {
+                        // If it's a groth16 proof, we need to get the proof bytes that we put on-chain.
+                        let proof_bytes = proof.bytes();
+                        ProofStatus {
+                            fulfillment_status: 3,
+                            execution_status: 2,
+                            proof: proof_bytes,
+                        }
+                    }
+                    SP1Proof::Plonk(_) => {
+                        // If it's a plonk proof, we need to get the proof bytes that we put on-chain.
+                        let proof_bytes = proof.bytes();
+                        ProofStatus {
+                            fulfillment_status: 3,
+                            execution_status: 2,
+                            proof: proof_bytes,
+                        }
+                    }
+                    _ => {
+                        log::error!("unknown proof type: {proof:?}");
+                        return Err(AppError(anyhow::anyhow!("unknown proof type: {proof:?}")));
+                    }
+                }
+            }
+            Err(e) => {
+                log::error!("error proving {e}");
+                return Err(AppError(anyhow::anyhow!("error proving {e}")));
+            }
+        };
+
+        info!("proof completed. id {:?}", proof_id);
+        let minutes = start_time.elapsed().as_secs_f64() / 60.0;
+        info!("Time to compute {proof_type} proof: {} minutes", minutes);
+
+        // update proof store
+        proof_store.write().await.insert(proof_id, proof_status);
+
+        Ok(())
+    });
+
+    Ok(proof_id_clone)
+}
+
+fn uuid_to_hex_bytes(uuid: Uuid) -> Vec<u8> {
+    format!("0x{:016x}", uuid.as_u128() >> 64).into_bytes()
 }
 
 pub struct AppError(anyhow::Error);

--- a/sigil/op-succinct/proposer/fallback/bin/server.rs
+++ b/sigil/op-succinct/proposer/fallback/bin/server.rs
@@ -595,6 +595,45 @@ async fn get_proof_status(
     let proof_id_bytes = hex::decode(&proof_id)?;
     let proof_id = B256::from_slice(&proof_id_bytes);
 
+    // request read-only copy of proof_store
+    let proof_store = state.proof_store.read().await;
+
+    // first check if this is a proof we're generating locally.  Otherwise check the network for it
+    if let Some(status) = proof_store.get(&proof_id) {
+        return Ok((
+            StatusCode::OK,
+            Json(ProofStatus {
+                fulfillment_status: status.fulfillment_status,
+                execution_status: status.execution_status,
+                proof: status.proof.clone(),
+            }),
+        ));
+    }
+
+    if state.local_proving_only == true {
+        // we should never get here.  If we're local proving only and a proof that was requested
+        // wasn't found locally we should send a response that prompts the proposer to retry that
+        // proof request.
+        error!(
+            "Status of proof {} not found locally.  Returning response to proposer to prompt retry",
+            proof_id
+        );
+
+        // When the proposer sees a FulfillmentStatus of Unfulfillable it will retry the proof
+        // request.  If the prover network is really down, the new request will fail inside
+        // `request_agg/span_proof()` and will be re-routed as a local proof
+        return Ok((
+            StatusCode::OK,
+            Json(ProofStatus {
+                fulfillment_status: FulfillmentStatus::Unfulfillable.into(),
+                // if execution status is also `Unexecutable`, then the retry proof request
+                // will be half the block size.  This keeps the request the same
+                execution_status: ExecutionStatus::UnspecifiedExecutionStatus.into(),
+                proof: vec![],
+            }),
+        ));
+    }
+
     let network_proof_status_request = || state.network_prover.get_proof_status(proof_id);
 
     // try to get the proof status, returning a failure to the proposer if it seems that the prover

--- a/sigil/op-succinct/proposer/fallback/bin/server.rs
+++ b/sigil/op-succinct/proposer/fallback/bin/server.rs
@@ -14,7 +14,7 @@ use op_succinct_client_utils::{
 };
 use op_succinct_fallback_proposer::{
     AggProofRequest, ProofResponse, ProofStatus, ProofStore, ProofType, SpanProofRequest,
-    SuccinctProposerConfig, ValidateConfigRequest, ValidateConfigResponse,
+    SuccinctProposerConfig, ValidateConfigRequest, ValidateConfigResponse, request_with_retries
 };
 use op_succinct_host_utils::{
     fetcher::{CacheMode, OPSuccinctDataFetcher, RunContext},
@@ -95,15 +95,12 @@ async fn main() -> Result<()> {
         _ => false,
     };
 
-    // defaults to 4 mins
-    let network_timeout_duration_secs = match env::var("NETWORK_TIMEOUT_DURATION_SECS") {
-        Ok(secs) => {
-            let secs: u64 = secs
-                .parse()
-                .context("parsing env var NETWORK_TIMEOUT_DURATION_SECS as u64")?;
-            Duration::from_secs(secs)
-        }
-        _ => Duration::from_secs(4 * 60),
+    // defaults to 3 retries
+    let prover_network_retries: usize = match env::var("PROVER_NETWORK_RETRIES") {
+        Ok(retries) => retries
+            .parse()
+            .context("parse PROVER_NETWORK_RETRIES as usize")?,
+        _ => 3,
     };
 
     // Initialize global hashes.
@@ -119,7 +116,7 @@ async fn main() -> Result<()> {
         agg_proof_strategy,
         agg_proof_mode,
         network_prover,
-        network_timeout_duration_secs,
+        prover_network_retries,
         proof_store,
         cuda_prover,
         local_proving_only,
@@ -223,24 +220,38 @@ async fn request_span_proof(
     };
 
     let proof_id = if state.local_proving_only {
-        todo!()
-        // send_proof(
-        //     ProofType::Span,
-        //     state.proof_store.clone(),
-        //     state.cuda_prover.clone(),
-        //     state.range_pk,
-        //     sp1_stdin,
-        // )
-        // .await?
-    } else {
-        match request_network_proof_with_timeout(
-            state.network_prover.clone(),
-            state.range_pk,
-            state.range_proof_strategy,
-            state.network_timeout_duration_secs,
-            &sp1_stdin,
+        send_proof(
+            ProofType::Span,
+            state.proof_store.clone(),
+            state.cuda_prover.clone(),
+            sp1_stdin,
         )
-        .await
+        .await?
+    } else {
+
+
+        let network_proof_request = || {
+state.network_prover
+        .prove(&state.range_pk, &sp1_stdin)
+        .compressed()
+        .strategy(state.range_proof_strategy)
+        .skip_simulation(true)
+        .cycle_limit(1_000_000_000_000)
+        .request_async()
+    };
+
+        match request_with_retries(state.prover_network_retries, 
+            network_proof_request
+).await
+
+        // match request_network_proof_with_retry(
+        //     state.network_prover.clone(),
+        //     state.range_pk,
+        //     state.range_proof_strategy,
+        //     state.retries,
+        //     &sp1_stdin,
+        // )
+        // .await
         {
             Ok(network_response) => network_response.map_err(|e| {
                 error!("Failed to request proof: {}", e);
@@ -250,7 +261,14 @@ async fn request_span_proof(
             Err(timeout) => {
                 // TODO: local proof req
                 warn!("Reached timeout before getting a response from prover network: {timeout}. Requesting proof locally.");
-                todo!()
+
+                send_proof(
+                    ProofType::Span,
+                    state.proof_store.clone(),
+                    state.cuda_prover.clone(),
+                    sp1_stdin,
+                )
+                .await?
             }
         }
     };
@@ -670,33 +688,6 @@ async fn get_proof_status(
     ))
 }
 
-// Sends a proof request to the prover network and times out if no response is
-// heard within the timeout period
-// TODO: make this work for agg proofs too
-async fn request_network_proof_with_timeout(
-    network_prover: Arc<NetworkProver>,
-    range_pk: Arc<SP1ProvingKey>,
-    range_proof_strategy: FulfillmentStrategy,
-    timeout_duration_secs: Duration,
-    sp1_stdin: &SP1Stdin,
-) -> Result<Result<B256>, Elapsed> {
-    timeout(
-        timeout_duration_secs,
-        network_prover
-            .prove(&range_pk, sp1_stdin)
-            .compressed()
-            .strategy(range_proof_strategy)
-            .skip_simulation(true)
-            .cycle_limit(1_000_000_000_000)
-            .request_async(), // .await
-                              // .map_err(|e| {
-                              //     error!("Failed to request proof: {}", e);
-                              //     AppError(anyhow::anyhow!("Failed to request proof: {}", e))
-                              // })?,
-    )
-    .await
-}
-
 // spawns a process that creates a proof locally
 // runs proof in a background thread.  Only needs to be async because of
 // proof_store.write().await.  It isn't blocked by anything else.
@@ -704,7 +695,6 @@ async fn send_proof(
     proof_type: ProofType,
     proof_store: ProofStore,
     cuda_prover: Arc<CudaProver>,
-    proving_key: SP1ProvingKey,
     sp1_stdin: SP1Stdin,
 ) -> Result<B256, AppError> {
     let proof_id = B256::random();
@@ -730,7 +720,7 @@ async fn send_proof(
                 // the cuda prover keeps state of the last `setup()` that was called on it.
                 // You must call `setup()` then `prove` *each* time you intend to
                 // prove a certain program
-                let _ = cuda_prover.setup(RANGE_ELF);
+                let (proving_key, _) = cuda_prover.setup(RANGE_ELF);
                 cuda_prover
                     .prove(&proving_key, &sp1_stdin)
                     .compressed()
@@ -740,7 +730,7 @@ async fn send_proof(
                 // the cuda prover keeps state of the last `setup()` that was called on it.
                 // You must call `setup()` then `prove` *each* time you intend to
                 // prove a certain program
-                let _ = cuda_prover.setup(AGG_ELF);
+                let (proving_key, _) = cuda_prover.setup(AGG_ELF);
                 cuda_prover.prove(&proving_key, &sp1_stdin).groth16().run()
             }
         };

--- a/sigil/op-succinct/proposer/fallback/bin/server.rs
+++ b/sigil/op-succinct/proposer/fallback/bin/server.rs
@@ -7,14 +7,14 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use log::{error, info, warn};
+use log::{error, info};
 use op_succinct_client_utils::{
     boot::{hash_rollup_config, BootInfoStruct},
     types::u32_to_u8,
 };
 use op_succinct_fallback_proposer::{
-    AggProofRequest, ProofResponse, ProofStatus, ProofStore, ProofType, SpanProofRequest,
-    SuccinctProposerConfig, ValidateConfigRequest, ValidateConfigResponse, request_with_retries
+    request_with_retries, AggProofRequest, ProofResponse, ProofStatus, ProofStore, ProofType,
+    SpanProofRequest, SuccinctProposerConfig, ValidateConfigRequest, ValidateConfigResponse,
 };
 use op_succinct_host_utils::{
     fetcher::{CacheMode, OPSuccinctDataFetcher, RunContext},
@@ -27,8 +27,8 @@ use sp1_sdk::{
         proto::network::{ExecutionStatus, FulfillmentStatus},
         FulfillmentStrategy,
     },
-    utils, CudaProver, HashableKey, NetworkProver, Prover, ProverClient, SP1Proof, SP1ProofMode,
-    SP1ProofWithPublicValues, SP1ProvingKey, SP1Stdin, SP1_CIRCUIT_VERSION,
+    utils, CudaProver, HashableKey, Prover, ProverClient, SP1Proof, SP1ProofMode,
+    SP1ProofWithPublicValues, SP1Stdin, SP1_CIRCUIT_VERSION,
 };
 use std::{
     collections::HashMap,
@@ -37,10 +37,7 @@ use std::{
     sync::Arc,
     time::{Instant, SystemTime, UNIX_EPOCH},
 };
-use tokio::{
-    sync::RwLock,
-    time::{error::Elapsed, timeout, Duration},
-};
+use tokio::sync::RwLock;
 use tower_http::limit::RequestBodyLimitLayer;
 
 pub const RANGE_ELF: &[u8] = include_bytes!("../../../elf/range-elf");
@@ -228,39 +225,23 @@ async fn request_span_proof(
         )
         .await?
     } else {
-
-
+        // future producing closure
         let network_proof_request = || {
-state.network_prover
-        .prove(&state.range_pk, &sp1_stdin)
-        .compressed()
-        .strategy(state.range_proof_strategy)
-        .skip_simulation(true)
-        .cycle_limit(1_000_000_000_000)
-        .request_async()
-    };
+            state
+                .network_prover
+                .prove(&state.range_pk, &sp1_stdin)
+                .compressed()
+                .strategy(state.range_proof_strategy)
+                .skip_simulation(true)
+                .cycle_limit(1_000_000_000_000)
+                .request_async()
+        };
 
-        match request_with_retries(state.prover_network_retries, 
-            network_proof_request
-).await
-
-        // match request_network_proof_with_retry(
-        //     state.network_prover.clone(),
-        //     state.range_pk,
-        //     state.range_proof_strategy,
-        //     state.retries,
-        //     &sp1_stdin,
-        // )
-        // .await
-        {
-            Ok(network_response) => network_response.map_err(|e| {
-                error!("Failed to request proof: {}", e);
-                AppError(anyhow::anyhow!("Failed to request proof: {}", e))
-            })?,
-            // TODO: this can be errors other than timeout, fix it
-            Err(timeout) => {
-                // TODO: local proof req
-                warn!("Reached timeout before getting a response from prover network: {timeout}. Requesting proof locally.");
+        // request the future a number of times
+        match request_with_retries(state.prover_network_retries, network_proof_request).await {
+            Ok(proof_id) => proof_id,
+            Err(_) => {
+                error!("Prover network request failed. Requesting proof locally.");
 
                 send_proof(
                     ProofType::Span,
@@ -358,7 +339,7 @@ async fn request_agg_proof(
         }
     };
 
-    let stdin =
+    let sp1_stdin =
         match get_agg_proof_stdin(proofs, boot_infos, headers, &state.range_vk, l1_head.into()) {
             Ok(s) => s,
             Err(e) => {
@@ -370,18 +351,39 @@ async fn request_agg_proof(
             }
         };
 
-    let proof_id = match state
-        .network_prover
-        .prove(&state.agg_pk, &stdin)
-        .mode(state.agg_proof_mode)
-        .strategy(state.agg_proof_strategy)
-        .request_async()
-        .await
-    {
-        Ok(id) => id,
-        Err(e) => {
-            error!("Failed to request proof: {}", e);
-            return Err(AppError(anyhow::anyhow!("Failed to request proof: {}", e)));
+    let proof_id = if state.local_proving_only {
+        send_proof(
+            ProofType::Agg,
+            state.proof_store.clone(),
+            state.cuda_prover.clone(),
+            sp1_stdin,
+        )
+        .await?
+    } else {
+        // future producing closure
+        let network_proof_request = || {
+            state
+                .network_prover
+                .prove(&state.agg_pk, &sp1_stdin)
+                .mode(state.agg_proof_mode)
+                .strategy(state.agg_proof_strategy)
+                .request_async()
+        };
+
+        // request the future a number of times
+        match request_with_retries(state.prover_network_retries, network_proof_request).await {
+            Ok(proof_id) => proof_id,
+            Err(_) => {
+                error!("Prover network request failed. Requesting proof locally.");
+
+                send_proof(
+                    ProofType::Agg,
+                    state.proof_store.clone(),
+                    state.cuda_prover.clone(),
+                    sp1_stdin,
+                )
+                .await?
+            }
         }
     };
 
@@ -698,7 +700,6 @@ async fn send_proof(
     sp1_stdin: SP1Stdin,
 ) -> Result<B256, AppError> {
     let proof_id = B256::random();
-    let proof_id_clone = proof_id.clone();
 
     let initial_status = ProofStatus {
         fulfillment_status: 2,
@@ -706,10 +707,7 @@ async fn send_proof(
         proof: Vec::new(),
     };
 
-    proof_store
-        .write()
-        .await
-        .insert(proof_id.clone(), initial_status);
+    proof_store.write().await.insert(proof_id, initial_status);
 
     tokio::spawn(async move {
         let start_time = tokio::time::Instant::now();
@@ -816,7 +814,7 @@ async fn send_proof(
         Ok(())
     });
 
-    Ok(proof_id_clone)
+    Ok(proof_id)
 }
 
 pub struct AppError(anyhow::Error);

--- a/sigil/op-succinct/proposer/fallback/build.rs
+++ b/sigil/op-succinct/proposer/fallback/build.rs
@@ -1,0 +1,5 @@
+use op_succinct_build_utils::build_all;
+
+fn main() {
+    build_all();
+}

--- a/sigil/op-succinct/proposer/fallback/src/lib.rs
+++ b/sigil/op-succinct/proposer/fallback/src/lib.rs
@@ -1,0 +1,109 @@
+use alloy_primitives::B256;
+use base64::{engine::general_purpose, Engine as _};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
+use sp1_sdk::{
+    network::FulfillmentStrategy, NetworkProver, SP1ProofMode, SP1ProvingKey, SP1VerifyingKey,
+};
+use std::sync::Arc;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ValidateConfigRequest {
+    pub address: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ValidateConfigResponse {
+    pub rollup_config_hash_valid: bool,
+    pub agg_vkey_valid: bool,
+    pub range_vkey_valid: bool,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct SpanProofRequest {
+    pub start: u64,
+    pub end: u64,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct AggProofRequest {
+    #[serde(deserialize_with = "deserialize_base64_vec")]
+    pub subproofs: Vec<Vec<u8>>,
+    pub head: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct MockProofResponse {
+    pub proof_id: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ProofResponse {
+    pub proof_id: Vec<u8>,
+}
+
+#[derive(Debug, Serialize_repr, Deserialize_repr)]
+#[repr(i32)]
+/// The type of error that occurred when unclaiming a proof. Based off of the `unclaim_description`
+/// field in the `ProofStatus` struct.
+pub enum UnclaimDescription {
+    UnexpectedProverError = 0,
+    ProgramExecutionError = 1,
+    CycleLimitExceeded = 2,
+    Other = 3,
+}
+
+/// Convert a string to an `UnclaimDescription`. These cover the common reasons why a proof might
+/// be unclaimed.
+impl From<String> for UnclaimDescription {
+    fn from(description: String) -> Self {
+        match description.as_str().to_lowercase().as_str() {
+            "unexpected prover error" => UnclaimDescription::UnexpectedProverError,
+            "program execution error" => UnclaimDescription::ProgramExecutionError,
+            "cycle limit exceeded" => UnclaimDescription::CycleLimitExceeded,
+            _ => UnclaimDescription::Other,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+/// The status of a proof request.
+pub struct ProofStatus {
+    // Note: Can't use `FulfillmentStatus`/`ExecutionStatus` directly because `Serialize_repr` and `Deserialize_repr` aren't derived on it.
+    pub fulfillment_status: i32,
+    pub execution_status: i32,
+    pub proof: Vec<u8>,
+}
+
+/// Configuration of the L2 Output Oracle contract. Created once at server start-up, monitors if there are any changes
+/// to the contract's configuration.
+#[derive(Clone)]
+pub struct SuccinctProposerConfig {
+    pub range_vk: Arc<SP1VerifyingKey>,
+    pub range_pk: Arc<SP1ProvingKey>,
+    pub agg_pk: Arc<SP1ProvingKey>,
+    pub agg_vk: Arc<SP1VerifyingKey>,
+    pub agg_vkey_hash: B256,
+    pub range_vkey_commitment: B256,
+    pub rollup_config_hash: B256,
+    pub range_proof_strategy: FulfillmentStrategy,
+    pub agg_proof_strategy: FulfillmentStrategy,
+    pub agg_proof_mode: SP1ProofMode,
+    pub network_prover: Arc<NetworkProver>,
+}
+
+/// Deserialize a vector of base64 strings into a vector of vectors of bytes. Go serializes
+/// the subproofs as base64 strings.
+fn deserialize_base64_vec<'de, D>(deserializer: D) -> Result<Vec<Vec<u8>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: Vec<String> = Deserialize::deserialize(deserializer)?;
+    s.into_iter()
+        .map(|base64_str| {
+            general_purpose::STANDARD
+                .decode(base64_str)
+                .map_err(serde::de::Error::custom)
+        })
+        .collect()
+}

--- a/sigil/op-succinct/proposer/fallback/src/lib.rs
+++ b/sigil/op-succinct/proposer/fallback/src/lib.rs
@@ -3,9 +3,11 @@ use base64::{engine::general_purpose, Engine as _};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use sp1_sdk::{
-    network::FulfillmentStrategy, NetworkProver, SP1ProofMode, SP1ProvingKey, SP1VerifyingKey,
+    network::FulfillmentStrategy, CudaProver, NetworkProver, SP1ProofMode, SP1ProvingKey,
+    SP1VerifyingKey,
 };
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
+use tokio::{sync::RwLock, time::Duration};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ValidateConfigRequest {
@@ -66,6 +68,11 @@ impl From<String> for UnclaimDescription {
     }
 }
 
+pub enum ProofType {
+    Span,
+    Agg,
+}
+
 #[derive(Serialize, Deserialize)]
 /// The status of a proof request.
 pub struct ProofStatus {
@@ -74,6 +81,8 @@ pub struct ProofStatus {
     pub execution_status: i32,
     pub proof: Vec<u8>,
 }
+
+pub type ProofStore = Arc<RwLock<HashMap<Vec<u8>, ProofStatus>>>;
 
 /// Configuration of the L2 Output Oracle contract. Created once at server start-up, monitors if there are any changes
 /// to the contract's configuration.
@@ -90,6 +99,14 @@ pub struct SuccinctProposerConfig {
     pub agg_proof_strategy: FulfillmentStrategy,
     pub agg_proof_mode: SP1ProofMode,
     pub network_prover: Arc<NetworkProver>,
+    // liveness check on the prover network for each proof request.
+    // If no response is heard within this time the proof is made locally
+    // TODO: what about when the network goes down while it's proving??
+    pub network_timeout_duration_secs: Duration,
+    // for local proving mode
+    pub proof_store: ProofStore,
+    pub cuda_prover: Arc<CudaProver>,
+    pub local_proving_only: bool,
 }
 
 /// Deserialize a vector of base64 strings into a vector of vectors of bytes. Go serializes

--- a/sigil/op-succinct/proposer/fallback/src/lib.rs
+++ b/sigil/op-succinct/proposer/fallback/src/lib.rs
@@ -29,11 +29,26 @@ pub struct SpanProofRequest {
     pub end: u64,
 }
 
+impl Display for SpanProofRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "proof start block: {}, proof end block: {}",
+            self.start, self.end
+        )
+    }
+}
+
 #[derive(Deserialize, Serialize, Debug)]
 pub struct AggProofRequest {
     #[serde(deserialize_with = "deserialize_base64_vec")]
     pub subproofs: Vec<Vec<u8>>,
     pub head: String,
+}
+
+pub enum GenericProofRequest {
+    Span(SpanProofRequest),
+    Agg(AggProofRequest),
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/sigil/op-succinct/proposer/fallback/src/lib.rs
+++ b/sigil/op-succinct/proposer/fallback/src/lib.rs
@@ -6,7 +6,7 @@ use sp1_sdk::{
     network::FulfillmentStrategy, CudaProver, NetworkProver, SP1ProofMode, SP1ProvingKey,
     SP1VerifyingKey,
 };
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, fmt::Display, sync::Arc};
 use tokio::{sync::RwLock, time::Duration};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -73,6 +73,15 @@ pub enum ProofType {
     Agg,
 }
 
+impl Display for ProofType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProofType::Span => write!(f, "span"),
+            ProofType::Agg => write!(f, "agg"),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 /// The status of a proof request.
 pub struct ProofStatus {
@@ -82,7 +91,7 @@ pub struct ProofStatus {
     pub proof: Vec<u8>,
 }
 
-pub type ProofStore = Arc<RwLock<HashMap<Vec<u8>, ProofStatus>>>;
+pub type ProofStore = Arc<RwLock<HashMap<B256, ProofStatus>>>;
 
 /// Configuration of the L2 Output Oracle contract. Created once at server start-up, monitors if there are any changes
 /// to the contract's configuration.

--- a/sigil/op-succinct/proposer/fallback/src/lib.rs
+++ b/sigil/op-succinct/proposer/fallback/src/lib.rs
@@ -9,7 +9,7 @@ use sp1_sdk::{
     SP1VerifyingKey,
 };
 use std::{collections::HashMap, fmt::Display, future::Future, sync::Arc};
-use tokio::{sync::RwLock, time::Duration};
+use tokio::sync::RwLock;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ValidateConfigRequest {

--- a/sigil/op-succinct/proposer/fallback/src/lib.rs
+++ b/sigil/op-succinct/proposer/fallback/src/lib.rs
@@ -1,12 +1,14 @@
 use alloy_primitives::B256;
+use anyhow::anyhow;
 use base64::{engine::general_purpose, Engine as _};
+use log::error;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use sp1_sdk::{
     network::FulfillmentStrategy, CudaProver, NetworkProver, SP1ProofMode, SP1ProvingKey,
     SP1VerifyingKey,
 };
-use std::{collections::HashMap, fmt::Display, sync::Arc};
+use std::{collections::HashMap, fmt::Display, future::Future, sync::Arc};
 use tokio::{sync::RwLock, time::Duration};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -108,10 +110,8 @@ pub struct SuccinctProposerConfig {
     pub agg_proof_strategy: FulfillmentStrategy,
     pub agg_proof_mode: SP1ProofMode,
     pub network_prover: Arc<NetworkProver>,
-    // liveness check on the prover network for each proof request.
-    // If no response is heard within this time the proof is made locally
-    // TODO: what about when the network goes down while it's proving??
-    pub network_timeout_duration_secs: Duration,
+    // how many retries on prover network requests until we fall back to local proof.
+    pub prover_network_retries: usize,
     // for local proving mode
     pub proof_store: ProofStore,
     pub cuda_prover: Arc<CudaProver>,
@@ -133,3 +133,58 @@ where
         })
         .collect()
 }
+
+pub async fn request_with_retries<F, Fut, T, E>(
+    max_retries: usize,
+    mut request_fn: F,
+) -> Result<T, anyhow::Error>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    E: Display,
+{
+    let mut retry_num = 0;
+    let mut last_error = None;
+
+    while retry_num < max_retries {
+        let request = request_fn();
+        match request.await {
+            Ok(res) => return Ok(res),
+            Err(err) => {
+                let error_msg = format!(
+                    "Prover network request retry {}/{} failed: {}",
+                    retry_num, max_retries, err
+                );
+                error!("{}", error_msg);
+
+                last_error = Some(anyhow!("{}", err));
+            }
+        }
+        retry_num += 1;
+    }
+
+    Err(anyhow!(
+        "All {} requests to the prover network failed. Last error: {}",
+        max_retries,
+        last_error.unwrap_or_else(|| anyhow!("Unknown error"))
+    ))
+}
+
+// async fn request_with_retries<T, E, Fut, F>(
+//     max_retries: usize,
+//     operation: F,
+// ) -> Result<T, anyhow::Error>
+// where
+//     E: Display,
+//     Fut: Future<Output = Result<T, E>>,
+//     F: Fn() -> Fut,
+// {
+//     let mut retry_num = 0;
+//     while retry_num < max_retries {
+//         match operation.await {
+//             Ok(res) => return Ok(res);
+//         }
+//     }
+//
+//     todo!()
+// }


### PR DESCRIPTION
The goal of this pr is to dynamically requests proofs locally using succinct's CUDA accelerated docker image when the prover network cannot be reached.

Adds env vars
 - `PROVER_NETWORK_RETRIES`: the number of times to retry a request to the prover network (in `request_agg_proof`, `request_span_proof`, or `get_proof_status`) before defaulting to requesting a local proof.  Defaults to `3`
 - `LOCAL_PROVING_ONLY`: If true, only makes local proofs and never uses the prover network.  Defaults to `false`

In both `request_agg_proof` an `request_span_proof`: Proof request is made to the network.  If it fails `PROVER_NETWORK_RETRIES` times, it will instead request the proof locally.

In `get_proof_status`, it first checks the status of the locally generating proof (if it exists locally, exits early if found), then queries the prover network endpoint.  If this query fails `PROVER_NETWORK_RETRIES` times, then we know the proof was originally sent to the network (doesn't exist locally), and that the network is now unreachable.  We can assume the prover network is down and respond to the proposer with a `ProofStatus` with `FulfillmentStatus::Unfulfillable`, which prompts the proposer to retry that proof request (see `monorepo/sigil/op-succinct/proposer/op/proposer/prove.go` ln 48).  

The new request will hit the `request_agg/span_proof` endpoint and fail `PROVER_NETWORK_RETRIES` times (because the prover network is down) and will then request the proof locally.

With this approach, our server will automatically switch back to using the prover network when it is back online.

An extension of this should be caching proofs to storage for persistence.
