### PR TITLE
feat: Server proof cache

### DIFF
--- a/sigil/op-succinct/.gitignore
+++ b/sigil/op-succinct/.gitignore
@@ -1,6 +1,9 @@
 # MacOS dust
 .DS_Store
 
+# default proof cache
+/proofs
+
 # build output
 /target
 

--- a/sigil/op-succinct/proposer/fallback/bin/server.rs
+++ b/sigil/op-succinct/proposer/fallback/bin/server.rs
@@ -13,8 +13,9 @@ use op_succinct_client_utils::{
     types::u32_to_u8,
 };
 use op_succinct_fallback_proposer::{
-    request_with_retries, AggProofRequest, ProofResponse, ProofStatus, ProofStore, ProofType,
-    SpanProofRequest, SuccinctProposerConfig, ValidateConfigRequest, ValidateConfigResponse,
+    request_with_retries, AggProofRequest, ProofCache, ProofResponse, ProofStatus, ProofStore,
+    ProofType, SpanProofRequest, SuccinctProposerConfig, ValidateConfigRequest,
+    ValidateConfigResponse,
 };
 use op_succinct_host_utils::{
     fetcher::{CacheMode, OPSuccinctDataFetcher, RunContext},
@@ -100,6 +101,19 @@ async fn main() -> Result<()> {
         _ => 3,
     };
 
+    // the amount of proofs to cache on-disk for persistence
+    // Stores the most recent PROOF_CACHE_MAX_SIZE completed proofs
+    // defaults to 10
+    // setting it to 0 disables the cache
+    let proof_cache_size: usize = match env::var("PROOF_CACHE_MAX_SIZE") {
+        Ok(size) => size
+            .parse()
+            .context("parse PROOF_CACHE_MAX_SIZE as usize")?,
+        _ => 10,
+    };
+
+    let proof_cache = Arc::new(RwLock::new(ProofCache::new(proof_cache_size)));
+
     // Initialize global hashes.
     let global_hashes = SuccinctProposerConfig {
         agg_vkey_hash,
@@ -117,6 +131,7 @@ async fn main() -> Result<()> {
         proof_store,
         cuda_prover,
         local_proving_only,
+        proof_cache,
     };
 
     let app = Router::new()

--- a/sigil/op-succinct/proposer/fallback/bin/server.rs
+++ b/sigil/op-succinct/proposer/fallback/bin/server.rs
@@ -198,6 +198,7 @@ async fn request_span_proof(
     drop(proof_cache);
 
     let proof_id = if proof_exists_on_disk {
+        info!("Span proof for request {:?} found on disk", payload);
         // We'll retrieve the proof later in `get_proof_status`.  For now, return a new proof_id to
         // the proposer
         B256::random()
@@ -246,6 +247,8 @@ async fn request_span_proof(
 
         route_proof(ProofType::Span, &state, sp1_stdin).await?
     };
+
+    info!("Assigned id {proof_id} to span proof request {:?}", payload);
 
     // get write copy of proof_cache
     let mut proof_cache = state.proof_cache.write().await;
@@ -765,6 +768,7 @@ async fn route_proof(
         )
         .await
     } else {
+        info!("Making network request for {} proof", proof_type);
         let prover_network_response = match proof_type {
             ProofType::Span => {
                 let network_request = || {

--- a/sigil/op-succinct/proposer/fallback/bin/server.rs
+++ b/sigil/op-succinct/proposer/fallback/bin/server.rs
@@ -112,7 +112,9 @@ async fn main() -> Result<()> {
         _ => 10,
     };
 
-    let proof_cache = Arc::new(RwLock::new(ProofCache::new(proof_cache_size)));
+    let proof_cache = Arc::new(RwLock::new(
+        ProofCache::new(proof_cache_size).context("Create proof cache")?,
+    ));
 
     // Initialize global hashes.
     let global_hashes = SuccinctProposerConfig {
@@ -231,7 +233,22 @@ async fn request_span_proof(
         }
     };
 
-    let proof_id = route_proof(ProofType::Span, &state, sp1_stdin).await?;
+    // get read only copy of proof cache
+    let proof_cache = state.proof_cache.read().await;
+    let proof_exists_on_disk = proof_cache.does_proof_exist_by_request(&payload);
+    let proof_exists_in_memory = proof_cache.drop(proof_cache);
+
+    let proof_id = if proof_exists_on_disk {
+        // a proof with these parameters exists on disk from a previous run, skip proof generation
+        // generate a new proof_id, put it into the cache,
+        B256::random()
+    } else {
+        route_proof(ProofType::Span, &state, sp1_stdin).await?
+    };
+
+    // get write lock
+    let mut proof_cache = state.proof_cache.write().await;
+    proof_cache.record_proof_request(&proof_id, &payload);
 
     Ok((
         StatusCode::OK,

--- a/sigil/op-succinct/proposer/fallback/bin/server.rs
+++ b/sigil/op-succinct/proposer/fallback/bin/server.rs
@@ -194,10 +194,12 @@ async fn request_span_proof(
     info!("Received span proof request: {:?}", payload);
 
     let proof_cache = state.proof_cache.read().await;
-    let proof_exists_on_disk = proof_cache.does_proof_exist_by_request(&payload);
+    let proof_exists_on_disk = proof_cache.proof_exists(&payload);
     drop(proof_cache);
 
     let proof_id = if proof_exists_on_disk {
+        // We'll retrieve the proof later in `get_proof_status`.  For now, return a new proof_id to
+        // the proposer
         B256::random()
     } else {
         let fetcher = match OPSuccinctDataFetcher::new_with_rollup_config(RunContext::Docker).await
@@ -245,12 +247,10 @@ async fn request_span_proof(
         route_proof(ProofType::Span, &state, sp1_stdin).await?
     };
 
-    // TODO: can we do this only in the case that the proof exists on-disk??
     // get write copy of proof_cache
     let mut proof_cache = state.proof_cache.write().await;
-    // make sure the proof_request is associated with the proof_id
+    // record all span proof requests in the lookup
     proof_cache.record_proof_request(&proof_id, &payload);
-    drop(proof_cache);
 
     Ok((
         StatusCode::OK,
@@ -572,11 +572,10 @@ async fn get_proof_status(
     // check if this is a proof we're generating locally.  Otherwise check the network for it
     let proof_store = state.proof_store.read().await;
     if let Some(status) = proof_store.get(&proof_id) {
-        // we don't have this in the cache, write it
-        let mut proof_cache = state.proof_cache.write().await;
-        proof_cache
-            .write_proof(status.proof.clone(), &proof_id)
-            .context("write locally constructed proof")?;
+        write_proof_to_cache(&state, status.proof.clone(), &proof_id)
+            .await
+            .context("locally generated proof")?;
+
         return Ok((
             StatusCode::OK,
             Json(ProofStatus {
@@ -586,6 +585,7 @@ async fn get_proof_status(
             }),
         ));
     }
+    drop(proof_store);
 
     if state.local_proving_only {
         // we should never get here.  If we're local proving only and a proof that was requested
@@ -715,11 +715,10 @@ async fn get_proof_status(
                 return Err(AppError(anyhow::anyhow!("unknown proof type: {proof:?}")));
             }
         };
-        // we don't have this proof in the cache, write it
-        let mut proof_cache = state.proof_cache.write().await;
-        proof_cache
-            .write_proof(proof_bytes.clone(), &proof_id)
-            .context("Write prover network proof")?;
+
+        write_proof_to_cache(&state, proof_bytes.clone(), &proof_id)
+            .await
+            .context("locally generated proof")?;
 
         return Ok((
             StatusCode::OK,
@@ -915,6 +914,25 @@ async fn locally_prove(
     });
 
     Ok(proof_id)
+}
+
+async fn write_proof_to_cache(
+    state: &SuccinctProposerConfig,
+    proof_bytes: Vec<u8>,
+    proof_id: &B256,
+) -> Result<()> {
+    // We don't have this proof in the cache, write it if it's a span proof (we don't cache agg
+    // proofs)
+    let mut proof_cache = state.proof_cache.write().await;
+    // We record all span proof requests via `proof_cache.record_proof_request`.  So if it's in
+    // the proof request mapping, it must be a span proof
+    if proof_cache.lookup_proof_request(proof_id).is_some() {
+        proof_cache
+            .write_proof(proof_bytes, proof_id)
+            .context("write locally constructed proof")?;
+    }
+
+    Ok(())
 }
 
 pub struct AppError(anyhow::Error);

--- a/sigil/op-succinct/proposer/fallback/bin/server.rs
+++ b/sigil/op-succinct/proposer/fallback/bin/server.rs
@@ -575,9 +575,16 @@ async fn get_proof_status(
     // check if this is a proof we're generating locally.  Otherwise check the network for it
     let proof_store = state.proof_store.read().await;
     if let Some(status) = proof_store.get(&proof_id) {
-        write_proof_to_cache(&state, status.proof.clone(), &proof_id)
-            .await
-            .context("locally generated proof")?;
+        // if the proof is done, write it to the cache
+        if status.fulfillment_status == FulfillmentStatus::Fulfilled.into() {
+            info!(
+                "Writing local proof with size {} to cache",
+                status.proof.len()
+            );
+            write_proof_to_cache(&state, status.proof.clone(), &proof_id)
+                .await
+                .context("locally generated proof")?;
+        }
 
         return Ok((
             StatusCode::OK,
@@ -721,7 +728,7 @@ async fn get_proof_status(
 
         write_proof_to_cache(&state, proof_bytes.clone(), &proof_id)
             .await
-            .context("locally generated proof")?;
+            .context("network proof")?;
 
         return Ok((
             StatusCode::OK,
@@ -929,7 +936,7 @@ async fn write_proof_to_cache(
     // proofs)
     let mut proof_cache = state.proof_cache.write().await;
     // We record all span proof requests via `proof_cache.record_proof_request`.  So if it's in
-    // the proof request mapping, it must be a span proof
+    // the proof request mapping, it must be a span proof.  We only want to cache span proofs
     if proof_cache.lookup_proof_request(proof_id).is_some() {
         proof_cache
             .write_proof(proof_bytes, proof_id)

--- a/sigil/op-succinct/proposer/fallback/bin/server.rs
+++ b/sigil/op-succinct/proposer/fallback/bin/server.rs
@@ -192,63 +192,65 @@ async fn request_span_proof(
     Json(payload): Json<SpanProofRequest>,
 ) -> Result<(StatusCode, Json<ProofResponse>), AppError> {
     info!("Received span proof request: {:?}", payload);
-    let fetcher = match OPSuccinctDataFetcher::new_with_rollup_config(RunContext::Docker).await {
-        Ok(f) => f,
-        Err(e) => {
-            error!("Failed to create data fetcher: {}", e);
-            return Err(AppError(e));
-        }
-    };
 
-    let host_args = match fetcher
-        .get_host_args(
-            payload.start,
-            payload.end,
-            None,
-            ProgramType::Multi,
-            CacheMode::DeleteCache,
-        )
-        .await
-    {
-        Ok(cli) => cli,
-        Err(e) => {
-            error!("Failed to get host CLI args: {}", e);
-            return Err(AppError(anyhow::anyhow!(
-                "Failed to get host CLI args: {}",
-                e
-            )));
-        }
-    };
-
-    let mem_kv_store = start_server_and_native_client(host_args).await?;
-
-    let sp1_stdin = match get_proof_stdin(mem_kv_store) {
-        Ok(stdin) => stdin,
-        Err(e) => {
-            error!("Failed to get proof stdin: {}", e);
-            return Err(AppError(anyhow::anyhow!(
-                "Failed to get proof stdin: {}",
-                e
-            )));
-        }
-    };
-
-    // get read only copy of proof cache
     let proof_cache = state.proof_cache.read().await;
     let proof_exists_on_disk = proof_cache.does_proof_exist_by_request(&payload);
-    let proof_exists_in_memory = proof_cache.drop(proof_cache);
+    drop(proof_cache);
 
     let proof_id = if proof_exists_on_disk {
-        // a proof with these parameters exists on disk from a previous run, skip proof generation
-        // generate a new proof_id, put it into the cache,
         B256::random()
     } else {
+        let fetcher = match OPSuccinctDataFetcher::new_with_rollup_config(RunContext::Docker).await
+        {
+            Ok(f) => f,
+            Err(e) => {
+                error!("Failed to create data fetcher: {}", e);
+                return Err(AppError(e));
+            }
+        };
+
+        let host_args = match fetcher
+            .get_host_args(
+                payload.start,
+                payload.end,
+                None,
+                ProgramType::Multi,
+                CacheMode::DeleteCache,
+            )
+            .await
+        {
+            Ok(cli) => cli,
+            Err(e) => {
+                error!("Failed to get host CLI args: {}", e);
+                return Err(AppError(anyhow::anyhow!(
+                    "Failed to get host CLI args: {}",
+                    e
+                )));
+            }
+        };
+
+        let mem_kv_store = start_server_and_native_client(host_args).await?;
+
+        let sp1_stdin = match get_proof_stdin(mem_kv_store) {
+            Ok(stdin) => stdin,
+            Err(e) => {
+                error!("Failed to get proof stdin: {}", e);
+                return Err(AppError(anyhow::anyhow!(
+                    "Failed to get proof stdin: {}",
+                    e
+                )));
+            }
+        };
+
         route_proof(ProofType::Span, &state, sp1_stdin).await?
     };
 
-    // get write lock
+    // TODO: can we do this only in the case that the proof exists on-disk??
+    // get write copy of proof_cache
     let mut proof_cache = state.proof_cache.write().await;
+    // make sure the proof_request is associated with the proof_id
     proof_cache.record_proof_request(&proof_id, &payload);
+    drop(proof_cache);
 
     Ok((
         StatusCode::OK,
@@ -553,11 +555,28 @@ async fn get_proof_status(
     let proof_id_bytes = hex::decode(&proof_id)?;
     let proof_id = B256::from_slice(&proof_id_bytes);
 
-    // request read-only copy of proof_store
-    let proof_store = state.proof_store.read().await;
+    // first, check to see if it's a proof we have stored in the cache
+    let proof_cache = state.proof_cache.read().await;
+    if let Some(proof_bytes) = proof_cache.read_proof(&proof_id).context("read proof")? {
+        return Ok((
+            StatusCode::OK,
+            Json(ProofStatus {
+                fulfillment_status: FulfillmentStatus::Fulfilled.into(),
+                execution_status: ExecutionStatus::Executed.into(),
+                proof: proof_bytes,
+            }),
+        ));
+    }
+    drop(proof_cache);
 
-    // first check if this is a proof we're generating locally.  Otherwise check the network for it
+    // check if this is a proof we're generating locally.  Otherwise check the network for it
+    let proof_store = state.proof_store.read().await;
     if let Some(status) = proof_store.get(&proof_id) {
+        // we don't have this in the cache, write it
+        let mut proof_cache = state.proof_cache.write().await;
+        proof_cache
+            .write_proof(status.proof.clone(), &proof_id)
+            .context("write locally constructed proof")?;
         return Ok((
             StatusCode::OK,
             Json(ProofStatus {
@@ -676,47 +695,40 @@ async fn get_proof_status(
     if fulfillment_status == FulfillmentStatus::Fulfilled as i32 {
         let proof: SP1ProofWithPublicValues = maybe_proof.unwrap();
 
-        match proof.proof {
+        let proof_bytes = match proof.proof {
             SP1Proof::Compressed(_) => {
                 // If it's a compressed proof, we need to serialize the entire struct with bincode.
                 // Note: We're re-serializing the entire struct with bincode here, but this is fine
                 // because we're on localhost and the size of the struct is small.
-                let proof_bytes = bincode::serialize(&proof).unwrap();
-                return Ok((
-                    StatusCode::OK,
-                    Json(ProofStatus {
-                        fulfillment_status,
-                        execution_status,
-                        proof: proof_bytes,
-                    }),
-                ));
+                bincode::serialize(&proof).unwrap()
             }
             SP1Proof::Groth16(_) => {
                 // If it's a groth16 proof, we need to get the proof bytes that we put on-chain.
-                let proof_bytes = proof.bytes();
-                return Ok((
-                    StatusCode::OK,
-                    Json(ProofStatus {
-                        fulfillment_status,
-                        execution_status,
-                        proof: proof_bytes,
-                    }),
-                ));
+                proof.bytes()
             }
             SP1Proof::Plonk(_) => {
                 // If it's a plonk proof, we need to get the proof bytes that we put on-chain.
-                let proof_bytes = proof.bytes();
-                return Ok((
-                    StatusCode::OK,
-                    Json(ProofStatus {
-                        fulfillment_status,
-                        execution_status,
-                        proof: proof_bytes,
-                    }),
-                ));
+                proof.bytes()
             }
-            _ => (),
-        }
+            _ => {
+                log::error!("unknown proof type: {proof:?}");
+                return Err(AppError(anyhow::anyhow!("unknown proof type: {proof:?}")));
+            }
+        };
+        // we don't have this proof in the cache, write it
+        let mut proof_cache = state.proof_cache.write().await;
+        proof_cache
+            .write_proof(proof_bytes.clone(), &proof_id)
+            .context("Write prover network proof")?;
+
+        return Ok((
+            StatusCode::OK,
+            Json(ProofStatus {
+                fulfillment_status,
+                execution_status,
+                proof: proof_bytes,
+            }),
+        ));
     } else if fulfillment_status == FulfillmentStatus::Unfulfillable as i32 {
         return Ok((
             StatusCode::OK,

--- a/sigil/op-succinct/proposer/fallback/bin/server.rs
+++ b/sigil/op-succinct/proposer/fallback/bin/server.rs
@@ -576,7 +576,8 @@ async fn get_proof_status(
     let proof_store = state.proof_store.read().await;
     if let Some(status) = proof_store.get(&proof_id) {
         // if the proof is done, write it to the cache
-        if status.fulfillment_status == FulfillmentStatus::Fulfilled.into() {
+        // (execution_status 2 = executed)
+        if status.execution_status == 2 {
             info!(
                 "Writing local proof with size {} to cache",
                 status.proof.len()

--- a/sigil/op-succinct/proposer/fallback/src/lib.rs
+++ b/sigil/op-succinct/proposer/fallback/src/lib.rs
@@ -25,7 +25,7 @@ pub struct ValidateConfigResponse {
     pub range_vkey_valid: bool,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, Default, Clone, Copy)]
 pub struct SpanProofRequest {
     pub start: u64,
     pub end: u64,

--- a/sigil/op-succinct/proposer/fallback/src/lib.rs
+++ b/sigil/op-succinct/proposer/fallback/src/lib.rs
@@ -48,11 +48,6 @@ pub struct AggProofRequest {
     pub head: String,
 }
 
-pub enum GenericProofRequest {
-    Span(SpanProofRequest),
-    Agg(AggProofRequest),
-}
-
 #[derive(Deserialize, Serialize, Debug)]
 pub struct MockProofResponse {
     pub proof_id: String,

--- a/sigil/op-succinct/proposer/fallback/src/lib.rs
+++ b/sigil/op-succinct/proposer/fallback/src/lib.rs
@@ -1,7 +1,9 @@
+pub mod proof_cache;
 use alloy_primitives::B256;
 use anyhow::anyhow;
 use base64::{engine::general_purpose, Engine as _};
 use log::error;
+pub use proof_cache::ProofCache;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use sp1_sdk::{
@@ -109,6 +111,7 @@ pub struct ProofStatus {
 }
 
 pub type ProofStore = Arc<RwLock<HashMap<B256, ProofStatus>>>;
+pub type ProofCacheWrapper = Arc<RwLock<ProofCache>>;
 
 /// Configuration of the L2 Output Oracle contract. Created once at server start-up, monitors if there are any changes
 /// to the contract's configuration.
@@ -131,6 +134,7 @@ pub struct SuccinctProposerConfig {
     pub proof_store: ProofStore,
     pub cuda_prover: Arc<CudaProver>,
     pub local_proving_only: bool,
+    pub proof_cache: ProofCacheWrapper,
 }
 
 /// Deserialize a vector of base64 strings into a vector of vectors of bytes. Go serializes
@@ -184,22 +188,3 @@ where
         last_error.unwrap_or_else(|| anyhow!("Unknown error"))
     ))
 }
-
-// async fn request_with_retries<T, E, Fut, F>(
-//     max_retries: usize,
-//     operation: F,
-// ) -> Result<T, anyhow::Error>
-// where
-//     E: Display,
-//     Fut: Future<Output = Result<T, E>>,
-//     F: Fn() -> Fut,
-// {
-//     let mut retry_num = 0;
-//     while retry_num < max_retries {
-//         match operation.await {
-//             Ok(res) => return Ok(res);
-//         }
-//     }
-//
-//     todo!()
-// }

--- a/sigil/op-succinct/proposer/fallback/src/proof_cache.rs
+++ b/sigil/op-succinct/proposer/fallback/src/proof_cache.rs
@@ -125,6 +125,11 @@ impl ProofCache {
             return Ok(());
         }
 
+        info!(
+            "num proof bytes in write proof in cache: {}",
+            proof_bytes.len()
+        );
+
         // overwrite the current_cache_index of cache_list
         let elem = self
             .cache_list

--- a/sigil/op-succinct/proposer/fallback/src/proof_cache.rs
+++ b/sigil/op-succinct/proposer/fallback/src/proof_cache.rs
@@ -1,15 +1,9 @@
-use crate::{GenericProofRequest, SpanProofRequest};
-use anyhow::{anyhow, Context, Result};
+use crate::SpanProofRequest;
+use anyhow::{Context, Result};
 use log::info;
 
-use super::ProofType;
 use alloy_primitives::B256;
-use std::{
-    collections::{HashMap, HashSet},
-    fs,
-    path::Path,
-    thread::current,
-};
+use std::{collections::HashMap, fs, path::Path};
 
 const PROOF_CACHE_DIR: &str = "proofs";
 
@@ -66,13 +60,17 @@ impl ProofCache {
         self.proof_request_lookup.insert(*proof_id, *proof_request);
     }
 
+    pub fn lookup_proof_request(&self, proof_id: &B256) -> Option<&SpanProofRequest> {
+        self.proof_request_lookup.get(proof_id)
+    }
+
     // If we have a proof locally we can save hours of time by skipping span proof generation.
     // This just returns true if it does indeed exist locally.
     // Careful: Just because it exists doesn't mean it is known by proof_request_lookup.  This is
     // guarded against by returning a proof_id to the proposer and subsequently calling record_proof_request
     // even when we already have the proof locally
     // Called in `request_span_proof`
-    pub fn does_proof_exist_by_request(&self, proof_request: &SpanProofRequest) -> bool {
+    pub fn proof_exists(&self, proof_request: &SpanProofRequest) -> bool {
         // if cache is disabled
         if self.cache_size == 0 {
             return false;
@@ -82,22 +80,6 @@ impl ProofCache {
         let proof_path = Path::new(&proof_path_name);
 
         proof_path.exists()
-    }
-
-    // this one is used in get_proof_status to first check to see if we need to acquire the lock on
-    // proof_cache to do a write_proof().  /get_proof_status is the most hit endpoint so we should be thread friendly
-    // there and avoid requesting the lock if we can.  Call this before calling write_proof to
-    // see if we don't need the lock
-    pub fn does_proof_exist_by_id(&self, proof_id: &B256) -> bool {
-        // if cache is disabled
-        if self.cache_size == 0 {
-            return false;
-        }
-
-        match self.proof_request_lookup.get(proof_id) {
-            Some(proof_request) => self.does_proof_exist_by_request(proof_request),
-            None => false,
-        }
     }
 
     // Retreive a proof that we previously computed.  This can save us hours of proving time.
@@ -137,7 +119,6 @@ impl ProofCache {
     // writes the completed proof to file, deleting the Least Recently Completed proof that the
     // cache is aware of.
     // Takes a mutable reference, so only use this if you're sure the proof isn't already on disk
-    // (i.e. does_proof_exist_by_id(proof_id) returns false)
     pub fn write_proof(&mut self, proof_bytes: Vec<u8>, proof_id: &B256) -> Result<()> {
         // if cache is disabled
         if self.cache_size == 0 {

--- a/sigil/op-succinct/proposer/fallback/src/proof_cache.rs
+++ b/sigil/op-succinct/proposer/fallback/src/proof_cache.rs
@@ -1,70 +1,186 @@
-use crate::GenericProofRequest;
-use anyhow::Result;
+use crate::{GenericProofRequest, SpanProofRequest};
+use anyhow::{anyhow, Context, Result};
+use log::info;
 
 use super::ProofType;
 use alloy_primitives::B256;
-use std::{collections::HashMap, thread::current};
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    path::Path,
+    thread::current,
+};
 
+const PROOF_CACHE_DIR: &str = "proofs";
+
+// If the proving server goes offline and it has completed some span proofs, when it comes back up
+// it will have to re-run those exact same spans.  Spans can take hours so we want some degree of
+// persistence for when the server binary is stopped & started.  At the very least for easier
+// debugging.
+
+// This cache writes span proofs to disk, using a LRU cache (more appropriately, Least Recently
+// Completed Proof).
 pub struct ProofCache {
     // max cache size.  Setting it to 0 disables the cache
     cache_size: usize,
-    // index of the next proof to insert
     // goes up to cache_size and loops.  Keeps track of the next proof to replace
+    // increments each time we write a proof to disk
     current_cache_index: usize,
     // when we get a new proof, replace the proof at current_index and also look it up in
     // proof_requests and evict the address that we just replaced
-    proof_ids_in_cache: Vec<B256>,
+    // (proof_id, proof_file_path_name)
+    cache_list: Vec<(B256, String)>,
+    proof_request_lookup: HashMap<B256, SpanProofRequest>,
 }
 
 impl ProofCache {
-    pub fn new(cache_size: usize) -> Self {
+    pub fn new(cache_size: usize) -> Result<Self> {
+        // Create `proofs/` directory if it doesn't already exist
+        let path = Path::new(PROOF_CACHE_DIR);
+        if !path.exists() {
+            info!("`proofs/` directory doesn't exist.  Creating it.");
+            fs::create_dir(path).context("Create proofs/ directory")?;
+        } else {
+            info!("Found `proofs/` directory.");
+        }
+
         let current_cache_index = 0;
-        let proof_ids_in_cache = Vec::with_capacity(cache_size);
-        Self {
+        let mut cache_list = Vec::with_capacity(cache_size);
+        // fill with default values so we never have to check if current_cache_index is out of
+        // bounds
+        cache_list.resize_with(cache_size, || (B256::default(), "empty".into()));
+
+        let proof_request_lookup = HashMap::new();
+
+        Ok(Self {
             cache_size,
             current_cache_index,
-            proof_ids_in_cache,
-        }
+            cache_list,
+            proof_request_lookup,
+        })
     }
 
-    pub fn get_proof(&self, proof_id: &B256) -> Option<Vec<u8>> {
+    // This is needed so in `write_proof()` we can get the proof file name (proof request start & end
+    // block) from the proof_id, which is the only argument we get sent in `/get_proof_status`
+    pub fn record_proof_request(&mut self, proof_id: &B256, proof_request: &SpanProofRequest) {
+        self.proof_request_lookup.insert(*proof_id, *proof_request);
+    }
+
+    // If we have a proof locally we can save hours of time by skipping span proof generation.
+    // This just returns true if it does indeed exist locally.
+    // Careful: Just because it exists doesn't mean it is known by proof_request_lookup.  This is
+    // guarded against by returning a proof_id to the proposer and subsequently calling record_proof_request
+    // even when we already have the proof locally
+    // Called in `request_span_proof`
+    pub fn does_proof_exist_by_request(&self, proof_request: &SpanProofRequest) -> bool {
         // if cache is disabled
         if self.cache_size == 0 {
-            return None;
+            return false;
         }
 
-        // load file with the proof_id
-        todo!()
+        let proof_path_name = proof_request_to_file_path(proof_request);
+        let proof_path = Path::new(&proof_path_name);
+
+        proof_path.exists()
     }
 
-    pub fn proof_completed(&mut self, proof_bytes: Vec<u8>, proof_id: &B256) -> Result<()> {
+    // this one is used in get_proof_status to first check to see if we need to acquire the lock on
+    // proof_cache to do a write_proof().  /get_proof_status is the most hit endpoint so we should be thread friendly
+    // there and avoid requesting the lock if we can.  Call this before calling write_proof to
+    // see if we don't need the lock
+    pub fn does_proof_exist_by_id(&self, proof_id: &B256) -> bool {
+        // if cache is disabled
+        if self.cache_size == 0 {
+            return false;
+        }
+
+        match self.proof_request_lookup.get(proof_id) {
+            Some(proof_request) => self.does_proof_exist_by_request(proof_request),
+            None => false,
+        }
+    }
+
+    // Retreive a proof that we previously computed.  This can save us hours of proving time.
+    // Safe to call even if we're not sure we have a proof.
+    // called in get_proof_status()
+    pub fn get_proof(&self, proof_id: &B256) -> Result<Option<Vec<u8>>> {
+        // if cache is disabled
+        if self.cache_size == 0 {
+            return Ok(None);
+        }
+
+        match self.proof_request_lookup.get(proof_id) {
+            Some(proof_request) => {
+                let proof_path_name = proof_request_to_file_path(proof_request);
+                let proof_path = Path::new(&proof_path_name);
+                if proof_path.exists() {
+                    info!(
+                        "Found cached span proof of request {}, loading from file {}",
+                        proof_request, proof_path_name
+                    );
+
+                    // load proof from file and return
+                    let proof_bytes = fs::read(proof_path)
+                        .context(format!("Reading proof from file {}", proof_path_name))?;
+                    Ok(Some(proof_bytes))
+                } else {
+                    // This means the proof is requested & the cache is aware of it (its in proof_request_lookup) but it hasn't
+                    // completed yet (didn't get written to disk in write_proof())
+                    Ok(None)
+                }
+            }
+            // we haven't received this proof request yet, it's not in the proof_request_lookup
+            None => Ok(None),
+        }
+    }
+
+    // writes the completed proof to file, deleting the Least Recently Completed proof that the
+    // cache is aware of.
+    // Takes a mutable reference, so only use this if you're sure the proof isn't already on disk
+    // (i.e. does_proof_exist_by_id(proof_id) returns false)
+    pub fn write_proof(&mut self, proof_bytes: Vec<u8>, proof_id: &B256) -> Result<()> {
         // if cache is disabled
         if self.cache_size == 0 {
             return Ok(());
         }
 
-        let current_cache_index = self.current_cache_index;
-        // if a proof exists at this index, kick it out (sorry!)
-        if let Some(proof_to_evict) = self.proof_ids_in_cache.get(current_cache_index) {
-            // delete file
+        // overwrite the current_cache_index of cache_list
+        let elem = self
+            .cache_list
+            .get_mut(self.current_cache_index)
+            .context(format!(
+                "Index {} out of bounds of cache_list vector",
+                self.current_cache_index,
+            ))?;
 
-            //
+        // if a proof exists here, evict it by deleting the file
+        let old_proof_path = Path::new(&elem.1);
+        if old_proof_path.exists() {
+            fs::remove_file(old_proof_path)
+                .context(format!("Delete old proof file {:?}", old_proof_path))?;
         }
-        // can I just overwrite that index safely here?
 
-        // write the new proof to file
+        // get proof request parameters (needed for proof file name) from the proof_id
+        let proof_request = self.proof_request_lookup.get(proof_id).context(format!(
+            "span proof id {} not found in request hashmap",
+            proof_id
+        ))?;
+        // get proof file name so we can write
+        let proof_path_name = proof_request_to_file_path(proof_request);
+        let path = Path::new(&proof_path_name);
 
-        if let Some(elem) = self.proof_ids_in_cache.get_mut(current_cache_index) {
-        } else {
-            return Err(anyhow!(
-                "Index {} out of bounds of cache vector which has length {}",
-                current_cache_index,
-                self.proof_ids_in_cache.len()
-            ));
-        }
+        // write completed proof to file
+        fs::write(path, proof_bytes).context(format!(
+            "Write proof id {} to file {}",
+            proof_id, proof_path_name
+        ))?;
+
+        // overwrite the current_cache_index in the cache_list vector with our newly written proof
+        let new_elem = (*proof_id, proof_path_name);
+        *elem = new_elem;
 
         self.increment_current_cache_index();
-        todo!()
+        Ok(())
     }
 
     fn increment_current_cache_index(&mut self) {
@@ -76,29 +192,56 @@ impl ProofCache {
     }
 }
 
-struct ProofMetaData {}
+fn proof_request_to_file_path(proof_request: &SpanProofRequest) -> String {
+    format!(
+        "{}/{}-{}",
+        PROOF_CACHE_DIR, proof_request.start, proof_request.end
+    )
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
+    fn test_constructor() {
+        let proof_cache = ProofCache::new(0).unwrap();
+        assert_eq!(proof_cache.cache_list.len(), 0);
+
+        let proof_cache = ProofCache::new(10).unwrap();
+        assert_eq!(proof_cache.cache_list.len(), 10);
+    }
+
+    #[test]
+    fn test_proof_request_to_file_path() {
+        let proof_request = SpanProofRequest {
+            start: 255,
+            end: 256,
+        };
+
+        let proof_file_path_name = proof_request_to_file_path(&proof_request);
+        let correct_proof_file_path_name = format!("{PROOF_CACHE_DIR}/255-256");
+
+        assert_eq!(proof_file_path_name, correct_proof_file_path_name);
+    }
+
+    #[test]
     fn test_increment_current_cache_index_0() {
-        let mut proof_cache = ProofCache::new(0);
+        let mut proof_cache = ProofCache::new(0).unwrap();
         proof_cache.increment_current_cache_index();
         assert_eq!(proof_cache.current_cache_index, 0);
     }
 
     #[test]
     fn test_increment_current_cache_index_1() {
-        let mut proof_cache = ProofCache::new(1);
+        let mut proof_cache = ProofCache::new(1).unwrap();
         proof_cache.increment_current_cache_index();
         assert_eq!(proof_cache.current_cache_index, 0);
     }
 
     #[test]
     fn test_increment_current_cache_index_2() {
-        let mut proof_cache = ProofCache::new(2);
+        let mut proof_cache = ProofCache::new(2).unwrap();
         proof_cache.increment_current_cache_index();
         assert_eq!(proof_cache.current_cache_index, 1);
         proof_cache.increment_current_cache_index();
@@ -109,7 +252,7 @@ mod tests {
 
     #[test]
     fn test_increment_current_cache_index_3() {
-        let mut proof_cache = ProofCache::new(3);
+        let mut proof_cache = ProofCache::new(3).unwrap();
         proof_cache.increment_current_cache_index();
         assert_eq!(proof_cache.current_cache_index, 1);
         proof_cache.increment_current_cache_index();

--- a/sigil/op-succinct/proposer/fallback/src/proof_cache.rs
+++ b/sigil/op-succinct/proposer/fallback/src/proof_cache.rs
@@ -103,7 +103,7 @@ impl ProofCache {
     // Retreive a proof that we previously computed.  This can save us hours of proving time.
     // Safe to call even if we're not sure we have a proof.
     // called in get_proof_status()
-    pub fn get_proof(&self, proof_id: &B256) -> Result<Option<Vec<u8>>> {
+    pub fn read_proof(&self, proof_id: &B256) -> Result<Option<Vec<u8>>> {
         // if cache is disabled
         if self.cache_size == 0 {
             return Ok(None);

--- a/sigil/op-succinct/proposer/fallback/src/proof_cache.rs
+++ b/sigil/op-succinct/proposer/fallback/src/proof_cache.rs
@@ -1,0 +1,120 @@
+use crate::GenericProofRequest;
+use anyhow::Result;
+
+use super::ProofType;
+use alloy_primitives::B256;
+use std::{collections::HashMap, thread::current};
+
+pub struct ProofCache {
+    // max cache size.  Setting it to 0 disables the cache
+    cache_size: usize,
+    // index of the next proof to insert
+    // goes up to cache_size and loops.  Keeps track of the next proof to replace
+    current_cache_index: usize,
+    // when we get a new proof, replace the proof at current_index and also look it up in
+    // proof_requests and evict the address that we just replaced
+    proof_ids_in_cache: Vec<B256>,
+}
+
+impl ProofCache {
+    pub fn new(cache_size: usize) -> Self {
+        let current_cache_index = 0;
+        let proof_ids_in_cache = Vec::with_capacity(cache_size);
+        Self {
+            cache_size,
+            current_cache_index,
+            proof_ids_in_cache,
+        }
+    }
+
+    pub fn get_proof(&self, proof_id: &B256) -> Option<Vec<u8>> {
+        // if cache is disabled
+        if self.cache_size == 0 {
+            return None;
+        }
+
+        // load file with the proof_id
+        todo!()
+    }
+
+    pub fn proof_completed(&mut self, proof_bytes: Vec<u8>, proof_id: &B256) -> Result<()> {
+        // if cache is disabled
+        if self.cache_size == 0 {
+            return Ok(());
+        }
+
+        let current_cache_index = self.current_cache_index;
+        // if a proof exists at this index, kick it out (sorry!)
+        if let Some(proof_to_evict) = self.proof_ids_in_cache.get(current_cache_index) {
+            // delete file
+
+            //
+        }
+        // can I just overwrite that index safely here?
+
+        // write the new proof to file
+
+        if let Some(elem) = self.proof_ids_in_cache.get_mut(current_cache_index) {
+        } else {
+            return Err(anyhow!(
+                "Index {} out of bounds of cache vector which has length {}",
+                current_cache_index,
+                self.proof_ids_in_cache.len()
+            ));
+        }
+
+        self.increment_current_cache_index();
+        todo!()
+    }
+
+    fn increment_current_cache_index(&mut self) {
+        if self.cache_size > 0 {
+            // increment by 1, looping to the start if its at capacity (cache_size)
+            let new_cache_index = (self.current_cache_index + 1) % self.cache_size;
+            self.current_cache_index = new_cache_index;
+        }
+    }
+}
+
+struct ProofMetaData {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_increment_current_cache_index_0() {
+        let mut proof_cache = ProofCache::new(0);
+        proof_cache.increment_current_cache_index();
+        assert_eq!(proof_cache.current_cache_index, 0);
+    }
+
+    #[test]
+    fn test_increment_current_cache_index_1() {
+        let mut proof_cache = ProofCache::new(1);
+        proof_cache.increment_current_cache_index();
+        assert_eq!(proof_cache.current_cache_index, 0);
+    }
+
+    #[test]
+    fn test_increment_current_cache_index_2() {
+        let mut proof_cache = ProofCache::new(2);
+        proof_cache.increment_current_cache_index();
+        assert_eq!(proof_cache.current_cache_index, 1);
+        proof_cache.increment_current_cache_index();
+        assert_eq!(proof_cache.current_cache_index, 0);
+        proof_cache.increment_current_cache_index();
+        assert_eq!(proof_cache.current_cache_index, 1);
+    }
+
+    #[test]
+    fn test_increment_current_cache_index_3() {
+        let mut proof_cache = ProofCache::new(3);
+        proof_cache.increment_current_cache_index();
+        assert_eq!(proof_cache.current_cache_index, 1);
+        proof_cache.increment_current_cache_index();
+        assert_eq!(proof_cache.current_cache_index, 2);
+        proof_cache.increment_current_cache_index();
+        assert_eq!(proof_cache.current_cache_index, 0);
+    }
+}


### PR DESCRIPTION
Writes the last `PROOF_CACHE_MAX_SIZE` (new env var, defaults to 10) span proofs to disk at time of completion.  Skips proof generation for span proof requests that already have a proof saved on-disk, potentially saving hours.

Tested writing & loading span proof on H100 server.